### PR TITLE
limited externall access to kafka on k8s

### DIFF
--- a/charts/cp-kafka/templates/external-service.yaml
+++ b/charts/cp-kafka/templates/external-service.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.external.enabled }}
+  {{- $fullName := include "cp-kafka.fullname" . }}
+  {{- $brokers := .Values.brokers | int }}
+  {{- $servicePort := .Values.external.servicePort }}
+  {{- $root := . }}
+  {{- range $i, $e := until $brokers }}
+    {{- $externalListenerPort := add $root.Values.external.firstListenerPort $i }}
+    {{- $responsiblePod := printf "%s-%d" (printf "%s" $fullName) $i }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ $root.Release.Name }}-{{ $i }}-external
+  labels:
+    app: {{ include "cp-kafka.name" $root }}
+    chart: {{ template "cp-kafka.chart" $root }}
+    release: {{ $root.Release.Name }}
+    heritage: {{ $root.Release.Service }}
+    pod: {{ $responsiblePod }}
+spec:
+  type: NodePort
+  ports:
+    - name: external-broker
+      port: {{ $servicePort }}
+      targetPort: {{ $externalListenerPort }}
+      nodePort: {{ $externalListenerPort }}
+      protocol: TCP
+  selector:
+    app: {{ include "cp-kafka.name" $root }}
+    release: {{ $root.Release.Name }}
+    statefulset.kubernetes.io/pod-name: {{ $responsiblePod | quote }}
+  {{- end }}
+{{- end }}

--- a/charts/cp-kafka/templates/statefulset.yaml
+++ b/charts/cp-kafka/templates/statefulset.yaml
@@ -1,3 +1,4 @@
+{{- $advertisedListenersOverride := first (pluck "advertised.listeners" .Values.configurationOverrides) }}
 apiVersion: apps/v1beta1
 kind: StatefulSet
 metadata:
@@ -58,9 +59,25 @@ spec:
         ports:
         - containerPort: 9092
           name: kafka
+        {{- if .Values.external.enabled }}
+          {{- $brokers := .Values.brokers | int }}
+          {{- $root := . }}
+          {{- range $i, $e := until $brokers }}
+        - containerPort: {{ add $root.Values.external.firstListenerPort $i }}
+          name: external-{{ $i }}
+          {{- end }}
+        {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         env:
+        - name: POD_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.podIP
+        - name: HOST_IP
+          valueFrom:
+            fieldRef:
+              fieldPath: status.hostIP
         - name: KAFKA_HEAP_OPTS
           value: {{ .Values.heapOptions }}
         {{- if not (hasKey .Values.configurationOverrides "zookeeper.connect") }}
@@ -79,10 +96,7 @@ spec:
         - name: KAFKA_JMX_PORT
           value: "{{ .Values.jmx.port }}"
         {{- end }}
-        - name: POD_IP
-          valueFrom:
-            fieldRef:
-              fieldPath: status.podIP
+
         # This is required because the Downward API does not yet support identification of
         # pod numbering in statefulsets. Thus, we are required to specify a command which
         # allows us to extract the pod ID for usage as the Kafka Broker ID.
@@ -92,7 +106,7 @@ spec:
         - -exc
         - |
           export KAFKA_BROKER_ID=${HOSTNAME##*-} && \
-          export KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://${POD_IP}:9092 && \
+          export KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://${POD_IP}:9092{{ if kindIs "string" $advertisedListenersOverride }}{{ printf ",%s" $advertisedListenersOverride }}{{ end }} && \
           exec /etc/confluent/docker/run
         volumeMounts:
         - name: datadir

--- a/charts/cp-kafka/values.yaml
+++ b/charts/cp-kafka/values.yaml
@@ -38,9 +38,6 @@ podManagementPolicy: Parallel
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
 updateStrategy: OnDelete
 
-configurationOverrides:
-  "offsets.topic.replication.factor": 3
-
 jmx:
   port: 5555
 
@@ -60,7 +57,28 @@ persistence:
   ##
   # storageClass:
 
+configurationOverrides:
+  "offsets.topic.replication.factor": 3
+  # "auto.leader.rebalance.enable": true
+  # "auto.create.topics.enable": true
+  # "controlled.shutdown.enable": true
+  # "controlled.shutdown.max.retries": 100
 
+
+#  "advertised.listeners": |-
+#    PLAINTEXT://$(POD_IP):9092
+#  "listener.security.protocol.map":
+#    PLAINTEXT:PLAINTEXT
+  ## Options required for external access via NodePort
+  ## ref:
+  ## - http://kafka.apache.org/documentation/#security_configbroker
+  ## - https://cwiki.apache.org/confluence/display/KAFKA/KIP-103%3A+Separation+of+Internal+and+External+traffic
+  ##
+  ## Setting "advertised.listeners" here appends to "PLAINTEXT://${POD_IP}:9092,"
+  "advertised.listeners": |-
+   EXTERNAL://${HOST_IP}:$((31090 + ${KAFKA_BROKER_ID}))
+  "listener.security.protocol.map": |-
+   PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
@@ -85,3 +103,8 @@ zookeeper:
   ## If the Zookeeper Chart is disabled a URL and port are required to connect
   url: ""
   clientPort: 2181
+
+external:
+  enabled: true
+  servicePort: 19092
+  firstListenerPort: 31090


### PR DESCRIPTION
This PR allows kafka on 8s to be accessible from outside but with in firewalls, Kafka expose brokers through Nodeport, whichever can access k8s node will be able to access kafka.