### PR TITLE
Seperated Zookeeper's Data Dir and Data Log Dir to different PV

### DIFF
--- a/charts/cp-zookeeper/README.md
+++ b/charts/cp-zookeeper/README.md
@@ -115,8 +115,10 @@ The configuration parameters in this section control the resources requested and
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `persistence.enabled` | Whether to create a PVC. If `false`, an `emptyDir` on the host will be used. | `true` |
-| `persistence.size` | Size of PVC that gets created. For production deployments this value should likely be much larger. | `5Gi` |
-| `persistence.storageClass` | Valid options: `nil`, `"-"`, or storage class name. See values.yaml for details. | `nil` |
+| `persistence.dataDirSize` | Size for Data dir, where ZooKeeper will store the in-memory database snapshots. | `5Gi` |
+| `persistence.dataDirStorageClass` | Valid options: `nil`, `"-"`, or storage class name. | `nil` |
+| `persistence.dataLogDirSize` | Size for data log dir, which is a dedicated log device to be used, and helps avoid competition between logging and snaphots. | `5Gi` |
+| `persistence.dataLogDirStorageClass` | Valid options: `nil`, `"-"`, or storage class name. | `nil` |
 
 ### Resources
 | Parameter | Description | Default |

--- a/charts/cp-zookeeper/templates/statefulset.yaml
+++ b/charts/cp-zookeeper/templates/statefulset.yaml
@@ -113,11 +113,14 @@ spec:
         - "ZOOKEEPER_SERVER_ID=$((${HOSTNAME##*-}+1)) && /etc/confluent/docker/run"
         volumeMounts:
         - name: datadir
-          mountPath: /var/lib/zookeeper
-          subPath: data
+          mountPath: /var/lib/zookeeper/data
+        - name: datalogdir
+          mountPath: /var/lib/zookeeper/log
       volumes:
       {{ if not .Values.persistence.enabled }}
       - name: datadir
+        emptyDir: {}
+      - name: datalogdir
         emptyDir: {}
       {{- end }}
       {{- if .Values.prometheus.jmx.enabled }}
@@ -133,12 +136,26 @@ spec:
       accessModes: [ "ReadWriteOnce" ]
       resources:
         requests:
-          storage: "{{ .Values.persistence.size }}"
-      {{- if .Values.persistence.storageClass }}
-      {{- if (eq "-" .Values.persistence.storageClass) }}
+          storage: "{{ .Values.persistence.dataDirSize }}"
+      {{- if .Values.persistence.dataDirStorageClass }}
+      {{- if (eq "-" .Values.persistence.dataDirStorageClass) }}
       storageClassName: ""
       {{- else }}
-      storageClassName: "{{ .Values.persistence.storageClass }}"
+      storageClassName: "{{ .Values.persistence.dataDirStorageClass }}"
+      {{- end }}
+      {{- end }}
+  - metadata:
+      name: datalogdir
+    spec:
+      accessModes: [ "ReadWriteOnce" ]
+      resources:
+        requests:
+          storage: "{{ .Values.persistence.dataLogDirSize }}"
+      {{- if .Values.persistence.dataLogDirSizeStorageClass }}
+      {{- if (eq "-" .Values.persistence.dataLogDirSizeStorageClass) }}
+      storageClassName: ""
+      {{- else }}
+      storageClassName: "{{ .Values.persistence.dataLogDirSizeStorageClass }}"
       {{- end }}
       {{- end }}
   {{- end }}

--- a/charts/cp-zookeeper/values.yaml
+++ b/charts/cp-zookeeper/values.yaml
@@ -54,7 +54,14 @@ persistence:
   ## The size of the PersistentVolume to allocate to each Zookeeper Pod in the StatefulSet. For
   ## production servers this number should likely be much larger.
   ##
-  size: 5Gi
+  ## Size for Data dir, where ZooKeeper will store the in-memory database snapshots.
+  dataDirSize: 5Gi
+  # dataDirStorageClass: ""
+
+  ## Size for data log dir, which is a dedicated log device to be used, and helps avoid competition between logging and snaphots.
+  dataLogDirSize: 5Gi
+  # dataLogDirStorageClass: ""
+
 
 ## Pod Compute Resources
 ## ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/


### PR DESCRIPTION
#14 According to https://zookeeper.apache.org/doc/r3.1.2/zookeeperAdmin.html
Having a dedicated log device has a large impact on throughput and stable latencies. It is highly recommened to dedicate a log device and set dataLogDir to point to a directory on that device, and then make sure to point dataDir to a directory not residing on that device.
Thus we'll mount dataDir and dataLogDir to different Persistent Volumes.