### PR TITLE
Removed all liveness and readiness probe

### DIFF
--- a/charts/cp-kafka-connect/README.md
+++ b/charts/cp-kafka-connect/README.md
@@ -81,12 +81,6 @@ The configuration parameters in this section control the resources requested and
 | `imageTag` | Docker Image Tag of Confluent REST Proxy. | `4.1.0` |
 | `imagePullPolicy` | Docker Image Tag of Confluent REST Proxy. | `IfNotPresent` |
 
-### Liveness and Readiness Probe Configuration
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `initialDelaySeconds` | Number of seconds after the container has started before probes are initiated. | `60` |
-| `timeoutSeconds` | Number of seconds after which the probe times out. | `10` |
-
 ### Port
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |

--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -27,18 +27,6 @@ spec:
             - name: kafka-connect
               containerPort: {{ .Values.servicePort}}
               protocol: TCP
-          livenessProbe:
-            httpGet:
-              path: /
-              port: kafka-connect
-            initialDelaySeconds: {{ .Values.initialDelaySeconds }}
-            timeoutSeconds: {{ .Values.timeoutSeconds }}
-          readinessProbe:
-            httpGet:
-              path: /
-              port: kafka-connect
-            initialDelaySeconds: {{ .Values.initialDelaySeconds }}
-            timeoutSeconds: {{ .Values.timeoutSeconds }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           env:

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -13,10 +13,6 @@ imageTag: 4.1.0
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
 imagePullPolicy: IfNotPresent
 
-## Liveness and Readiness Probe Configuration
-initialDelaySeconds: 60
-timeoutSeconds: 10
-
 servicePort: 8083
 
 resources: {}

--- a/charts/cp-kafka-rest/README.md
+++ b/charts/cp-kafka-rest/README.md
@@ -87,12 +87,6 @@ The configuration parameters in this section control the resources requested and
 | `imageTag` | Docker Image Tag of Confluent REST Proxy. | `4.1.0` |
 | `imagePullPolicy` | Docker Image Tag of Confluent REST Proxy. | `IfNotPresent` |
 
-### Liveness and Readiness Probe Configuration
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `initialDelaySeconds` | Number of seconds after the container has started before probes are initiated. | `60` |
-| `timeoutSeconds` | Number of seconds after which the probe times out. | `10` |
-
 ### Port
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |

--- a/charts/cp-kafka-rest/templates/deployment.yaml
+++ b/charts/cp-kafka-rest/templates/deployment.yaml
@@ -57,20 +57,6 @@ spec:
             - containerPort: {{ .Values.jmx.port }}
               name: jmx
             {{- end }}
-#          livenessProbe:
-#            exec:
-#              command:
-#                - sh
-#                - -ec
-#                - /usr/bin/jps | /bin/grep -q KafkaRestMain
-#            initialDelaySeconds: {{ .Values.initialDelaySeconds }}
-#            timeoutSeconds: {{ .Values.timeoutSeconds }}
-#          readinessProbe:
-#            httpGet:
-#              path: /
-#              port: rest-proxy
-#            initialDelaySeconds: {{ .Values.initialDelaySeconds }}
-#            timeoutSeconds: {{ .Values.timeoutSeconds }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           env:

--- a/charts/cp-kafka-rest/values.yaml
+++ b/charts/cp-kafka-rest/values.yaml
@@ -13,10 +13,6 @@ imageTag: 4.1.0
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
 imagePullPolicy: IfNotPresent
 
-## Liveness and Readiness Probe Configuration
-initialDelaySeconds: 60
-timeoutSeconds: 10
-
 servicePort: 8082
 
 resources: {}

--- a/charts/cp-kafka/README.md
+++ b/charts/cp-kafka/README.md
@@ -111,17 +111,6 @@ The configuration parameters in this section control the resources requested and
 | `podManagementPolicy` | The Kafka StatefulSet Pod Management Policy: `Parallel` or `OrderedReady`. | `OrderedReady` |
 | `updateStrategy` | The Kafka StatefulSet update strategy: `RollingUpdate` or `OnDelete`. | `OnDelete` |
 
-### Liveness and Readiness Probe Configuration
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `livenessProbe.initialDelaySeconds` | Number of seconds after the container has started before probes are initiated. | `60` |
-| `livenessProbe.timeoutSeconds` | Number of seconds after which the probe times out. | `10` |
-| `readinessProbe.initialDelaySeconds` | Number of seconds after the container has started before probes are initiated. | `60` |
-| `readinessProbe.timeoutSeconds` | Number of seconds after which the probe times out. | `10` |
-| `readinessProbe.periodSeconds` | How often (in seconds) to perform the probe. | `10` |
-| `readinessProbe.successThreshold` | Minimum consecutive successes for the probe to be considered successful after having failed.  | `1` |
-| `readinessProbe.failureThreshold` | The amount of time before the probes are considered to be failed due to a timeout. | `3` |
-
 ### Confluent Kafka Configuration
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
@@ -133,6 +122,11 @@ The configuration parameters in this section control the resources requested and
 | `persistence.enabled` | Whether to create a PVC. If `false`, an `emptyDir` on the host will be used. | `true` |
 | `persistence.size` | Size for log dir, where Kafka will store log data. | `5Gi` |
 | `persistence.storageClass` | Valid options: `nil`, `"-"`, or storage class name. | `nil` |
+
+### Kafka JVM Heap Options
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `heapOptions` | The JVM Heap Options for Kafka | `"-Xms1G -Xmx1G"` |
 
 ### Resources
 | Parameter | Description | Default |

--- a/charts/cp-kafka/templates/_helpers.tpl
+++ b/charts/cp-kafka/templates/_helpers.tpl
@@ -46,7 +46,7 @@ else use user-provided URL
 */}}
 {{- define "cp-kafka.cp-zookeeper.service-name" }}
 {{- if (index .Values "cp-zookeeper" "enabled") -}}
-{{- printf "%s:2181" (include "cp-kafka.cp-zookeeper.fullname" .) }}
+{{- printf "%s-headless:2181" (include "cp-kafka.cp-zookeeper.fullname" .) }}
 {{- else -}}
 {{- $zookeeperConnect := printf "%s" (index .Values "cp-zookeeper" "url") }}
 {{- $zookeeperConnectOverride := (index .Values "configurationOverrides" "zookeeper.connect") }}

--- a/charts/cp-kafka/templates/statefulset.yaml
+++ b/charts/cp-kafka/templates/statefulset.yaml
@@ -66,22 +66,6 @@ spec:
       - name: {{ template "cp-kafka.name" . }}-broker
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
-#        livenessProbe:
-#          exec:
-#            command:
-#              - sh
-#              - -ec
-#              - /usr/bin/jps | /bin/grep -q SupportedKafka
-#          initialDelaySeconds: {{ .Values.livenessProbe.initialDelaySeconds }}
-#          timeoutSeconds: {{ .Values.livenessProbe.timeoutSeconds }}
-#        readinessProbe:
-#          tcpSocket:
-#            port: kafka
-#          initialDelaySeconds: {{ .Values.readinessProbe.initialDelaySeconds }}
-#          periodSeconds: {{ .Values.readinessProbe.periodSeconds }}
-#          timeoutSeconds: {{ .Values.readinessProbe.timeoutSeconds }}
-#          successThreshold: {{ .Values.readinessProbe.successThreshold }}
-#          failureThreshold: {{ .Values.readinessProbe.failureThreshold }}
         ports:
         - containerPort: 9092
           name: kafka
@@ -116,7 +100,7 @@ spec:
         {{- end }}
         {{- if not (hasKey .Values.configurationOverrides "log.dirs") }}
         - name: KAFKA_LOG_DIRS
-          value: "/var/lib/kafka/data"
+          value: "/opt/kafka/data/logs"
         {{- end }}
         {{- range $key, $value := .Values.configurationOverrides }}
         - name: {{ printf "KAFKA_%s" $key | replace "." "_" | upper | quote }}
@@ -139,7 +123,7 @@ spec:
           exec /etc/confluent/docker/run
         volumeMounts:
         - name: datadir
-          mountPath: /var/lib/kafka/
+          mountPath: /opt/kafka/data
       volumes:
       {{- if not .Values.persistence.enabled }}
       - name: datadir

--- a/charts/cp-kafka/values.yaml
+++ b/charts/cp-kafka/values.yaml
@@ -27,21 +27,10 @@ podManagementPolicy: OrderedReady
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
 updateStrategy: RollingUpdate
 
-## Liveness and Readiness Probe Configuration
-livenessProbe:
-  initialDelaySeconds: 60
-  timeoutSeconds: 10
-readinessProbe:
-  initialDelaySeconds: 60
-  timeoutSeconds: 10
-  periodSeconds: 10
-  successThreshold: 1
-  failureThreshold: 3
-
 ## Kafka Server properties
 ## ref: https://kafka.apache.org/documentation/#configuration
 configurationOverrides:
-  "log.dirs": /var/lib/kafka/data
+  "log.dirs": /opt/kafka/data/logs
   "offsets.topic.replication.factor": 3
   # "default.replication.factor": 3
   # "min.insync.replicas": 2
@@ -73,6 +62,9 @@ persistence:
   ##   GKE, AWS & OpenStack)
   ##
   # storageClass: ""
+
+## Kafka JVM Heap Option
+heapOptions: "-Xms1G -Xmx1G"
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/cp-schema-registry/README.md
+++ b/charts/cp-schema-registry/README.md
@@ -86,12 +86,6 @@ The configuration parameters in this section control the resources requested and
 | `imageTag` | Docker Image Tag of Confluent Schema Registry. | `4.1.0` |
 | `imagePullPolicy` | Docker Image Tag of Confluent Schema Registry. | `IfNotPresent` |
 
-### Liveness and Readiness Probe Configuration
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `initialDelaySeconds` | Number of seconds after the container has started before probes are initiated. | `60` |
-| `timeoutSeconds` | Number of seconds after which the probe times out. | `10` |
-
 ### Confluent Schema Registry Configuration
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |

--- a/charts/cp-schema-registry/templates/deployment.yaml
+++ b/charts/cp-schema-registry/templates/deployment.yaml
@@ -57,20 +57,6 @@ spec:
             - containerPort: {{ .Values.jmx.port }}
               name: jmx
             {{- end }}
-#          livenessProbe:
-#            exec:
-#              command:
-#                - sh
-#                - -ec
-#                - /usr/bin/jps | /bin/grep -q SchemaRegistryMain
-#            initialDelaySeconds: {{ .Values.initialDelaySeconds }}
-#            timeoutSeconds: {{ .Values.timeoutSeconds }}
-#          readinessProbe:
-#            httpGet:
-#              path: /
-#              port: schema-registry
-#            initialDelaySeconds: {{ .Values.initialDelaySeconds }}
-#            timeoutSeconds: {{ .Values.timeoutSeconds }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
           env:

--- a/charts/cp-schema-registry/values.yaml
+++ b/charts/cp-schema-registry/values.yaml
@@ -18,10 +18,6 @@ imageTag: 4.1.0
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
 imagePullPolicy: IfNotPresent
 
-## Liveness and Readiness Probe Configuration
-initialDelaySeconds: 60
-timeoutSeconds: 10
-
 ## Schema Registry Settings Overrides
 ## Configuration Options can be found here: https://docs.confluent.io/current/schema-registry/docs/config.html
 configurationOverrides: {}

--- a/charts/cp-zookeeper/README.md
+++ b/charts/cp-zookeeper/README.md
@@ -102,12 +102,6 @@ The configuration parameters in this section control the resources requested and
 | `podManagementPolicy` | The Zookeeper StatefulSet Pod Management Policy: `Parallel` or `OrderedReady`. | `OrderedReady` |
 | `updateStrategy` | The ZooKeeper StatefulSet update strategy: `RollingUpdate` or `OnDelete`. | `RollingUpdate` |
 
-### Liveness and Readiness Probe Configuration
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `probeInitialDelaySeconds` | The initial delay before the liveness and readiness probes will be invoked. | `15` |
-| `probeTimeoutSeconds` | The amount of time before the probes are considered to be failed due to a timeout. | `5` |
-
 ### Confluent Zookeeper Configuration
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
@@ -117,6 +111,11 @@ The configuration parameters in this section control the resources requested and
 | `maxClientCnxns` | Limits the number of concurrent connections (at the socket level) that a single client, identified by IP address, may make to a single member of the ZooKeeper ensemble. This is used to prevent certain classes of DoS attacks, including file descriptor exhaustion. | `60` |
 | `autoPurgeSnapRetainCount` | When enabled, ZooKeeper auto purge feature retains the autopurge.snapRetainCount most recent snapshots and the corresponding transaction logs in the dataDir and dataLogDir respectively and deletes the rest. | `3` |
 | `autoPurgePurgeInterval` | The time interval in hours for which the purge task has to be triggered. Set to a positive integer (1 and above) to enable the auto purging. | `72` |
+
+### Zookeeper JVM Heap Options
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `heapOptions` | The JVM Heap Options for Zookeeper | `"-Xms512M -Xmx512M"` |
 
 ### Port
 | Parameter | Description | Default |

--- a/charts/cp-zookeeper/templates/statefulset.yaml
+++ b/charts/cp-zookeeper/templates/statefulset.yaml
@@ -65,16 +65,11 @@ spec:
       - name: {{ template "cp-zookeeper.name" . }}-server
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
-#        readinessProbe:
-#          exec:
-#            command: ['/bin/bash', '-c', 'echo "ruok" | nc -w 2 -q 2 localhost 2181 | grep imok']
-#          initialDelaySeconds: {{ .Values.probeInitialDelaySeconds }}
-#          timeoutSeconds: {{ .Values.probeTimeoutSeconds }}
-#        livenessProbe:
-#          exec:
-#            command: ['/bin/bash', '-c', 'echo "ruok" | nc -w 2 -q 2 localhost 2181 | grep imok']
-#          initialDelaySeconds: {{ .Values.probeInitialDelaySeconds }}
-#          timeoutSeconds: {{ .Values.probeTimeoutSeconds }}
+        livenessProbe:
+          exec:
+            command: ['/bin/bash', '-c', 'echo "ruok" | nc -w 2 -q 2 localhost 2181 | grep imok']
+          initialDelaySeconds: 1
+          timeoutSeconds: 3
         ports:
         - containerPort: {{ .Values.clientPort }}
           name: client
@@ -89,6 +84,8 @@ spec:
         resources:
 {{ toYaml .Values.resources | indent 10 }}
         env:
+        - name : KAFKA_HEAP_OPTS
+          value: "{{ .Values.heapOptions }}"
         {{- if .Values.jmx.port }}
         - name : KAFKA_JMX_PORT
           value: "{{ .Values.jmx.port }}"

--- a/charts/cp-zookeeper/values.yaml
+++ b/charts/cp-zookeeper/values.yaml
@@ -30,11 +30,6 @@ podManagementPolicy: OrderedReady
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
 updateStrategy: RollingUpdate
 
-## Liveness and Readiness Probe Configuration
-## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-probes/
-probeInitialDelaySeconds: 15
-probeTimeoutSeconds: 5
-
 ## Zookeeper Configuration
 ## ref: https://zookeeper.apache.org/doc/r3.4.10/zookeeperAdmin.html#sc_configuration
 ## ref: https://docs.confluent.io/current/zookeeper/deployment.html#important-configuration-options
@@ -44,6 +39,9 @@ initLimit: 10
 maxClientCnxns: 60
 autoPurgeSnapRetainCount: 3
 autoPurgePurgeInterval: 24
+
+## Zookeeper JVM Heap Option
+heapOptions: "-Xms512M -Xmx512M"
 
 ## Port
 ## ref: https://zookeeper.apache.org/doc/r3.4.10/zookeeperAdmin.html#sc_configuration

--- a/values.yaml
+++ b/values.yaml
@@ -6,6 +6,7 @@ cp-zookeeper:
   servers: 3
   image: confluentinc/cp-zookeeper
   imageTag: 4.1.0
+  heapOptions: "-Xms512M -Xmx512M"
   persistence:
     enabled: true
     ## The size of the PersistentVolume to allocate to each Zookeeper Pod in the StatefulSet. For
@@ -36,6 +37,7 @@ cp-kafka:
   brokers: 3
   image: confluentinc/cp-kafka
   imageTag: 4.1.0
+  heapOptions: "-Xms1024M -Xmx1024M"
   persistence:
     enabled: true
     # storageClass: ""


### PR DESCRIPTION
Original liveness and readiness triggers a lot removal/restart of pods during a heavy load test. Need to research more on proper ways to configure and reasonable values.