### PR TITLE
Kubernetes version needs to be 1.9.2+ instead of 1.8.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ sudo chmod u+s $(brew --prefix)/opt/docker-machine-driver-xhyve/bin/docker-mac
 1. Start Minikube. In the command below, note that memory has been increased to 6096 MB and it uses the xhyve driver for the native OS X hypervisor.
 
 ```sh
-$ minikube start --kubernetes-version v1.8.0 --cpus 4 --memory 6096 --vm-driver=xhyve --v=8
+$ minikube start --kubernetes-version v1.9.4 --cpus 4 --memory 6096 --vm-driver=xhyve --v=8
 ```
 
 2. Continue to check status of your local Kubernetes cluster until both minikube and cluster are in Running state


### PR DESCRIPTION
As we test with Kubernetes version 1.9.2+ as stated above in the document, we should not use v1.8.0 in minikube. v1.9.2 seems not available in minikube, so I changed the script to v1.9.4