### PR TITLE
Correctly pass "dataLogDirStorageClass" to the ZK's manifest

### DIFF
--- a/charts/cp-zookeeper/templates/statefulset.yaml
+++ b/charts/cp-zookeeper/templates/statefulset.yaml
@@ -156,11 +156,11 @@ spec:
       resources:
         requests:
           storage: "{{ .Values.persistence.dataLogDirSize }}"
-      {{- if .Values.persistence.dataLogDirSizeStorageClass }}
-      {{- if (eq "-" .Values.persistence.dataLogDirSizeStorageClass) }}
+      {{- if .Values.persistence.dataLogDirStorageClass }}
+      {{- if (eq "-" .Values.persistence.dataLogDirStorageClass) }}
       storageClassName: ""
       {{- else }}
-      storageClassName: "{{ .Values.persistence.dataLogDirSizeStorageClass }}"
+      storageClassName: "{{ .Values.persistence.dataLogDirStorageClass }}"
       {{- end }}
       {{- end }}
   {{- end }}


### PR DESCRIPTION
I just found a typo while trying to set the dataLogDirStorageClass for Zookeeper. Here is a quick fix for it.

BR
David