### PR TITLE
Add option to persist cp-kafka-connect plugins

### DIFF
--- a/charts/cp-kafka-connect/templates/_helpers.tpl
+++ b/charts/cp-kafka-connect/templates/_helpers.tpl
@@ -79,3 +79,14 @@ Default GroupId to Release Name but allow it to be overridden
 {{- .Release.Name -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Return combined plugin path if a pluginVolume is requested
+*/}}
+{{- define "cp-kafka-connect.pluginPath" -}}
+{{- if .Values.pluginVolume.enabled -}}
+{{- printf "%s, %s" .Values.pluginPath .Values.pluginVolume.path -}}
+{{- else -}}
+{{- .Values.pluginPath -}}
+{{- end -}}
+{{- end -}}

--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -33,7 +33,7 @@ spec:
         - -c
         - |
           set -ex
-          mkdir /plugins/tar
+          mkdir -p /plugins/tar
           cd /plugins/tar
           {{- range .Values.downloadPlugins }}
           echo {{ . }} >> plugins

--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -49,6 +49,11 @@ spec:
         - name: {{ template "cp-kafka-connect.name" . }}-server
           image: "{{ .Values.image }}:{{ .Values.imageTag }}"
           imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+          {{- if .Values.pluginVolume.enabled }}
+          volumeMounts:
+          - mountPath: {{ .Values.pluginVolume.path }}
+            name: connect-plugins
+          {{- end }}
           ports:
             - name: kafka-connect
               containerPort: {{ .Values.servicePort}}
@@ -65,7 +70,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: CONNECT_PLUGIN_PATH
-              value: {{ .Values.pluginPath }}
+              value: {{ template "cp-kafka-connect.pluginPath" }}
             - name: CONNECT_BOOTSTRAP_SERVERS
               value: {{ template "cp-kafka-connect.kafka.bootstrapServers" . }}
             - name: CONNECT_GROUP_ID
@@ -102,3 +107,10 @@ spec:
         configMap:
           name: {{ template "cp-kafka-connect.fullname" . }}-jmx-configmap
       {{- end }}
+      {{- if .Values.pluginVolume.enabled }}
+      - name: connect-plugins
+        persistentVolumeClaim:
+          claimName: {{ template "cp-kafka-connect.fullname" . }}-plugins
+      {{- end }}
+          
+        

--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -24,6 +24,36 @@ spec:
         prometheus.io/port: {{ .Values.prometheus.jmx.port | quote }}
       {{- end }}
     spec:
+      {{- if .Values.downloadPlugins }}
+      initContainers:
+      - name: download-plugins
+        image: busybox
+        command:
+        - sh
+        - -c
+        - |
+          set -ex
+          mkdir /plugins/tar
+          cd /plugins/tar
+          {{- range .Values.downloadPlugins }}
+          echo {{ . }} >> plugins
+          {{- end }}
+          touch loaded
+          while read url
+          do
+            if ! grep -q $url loaded; then
+              wget $url
+              filename="$(echo $url | rev | cut -d/ -f 1 | rev)"
+              tar -xvf $filename -C ../
+              rm $filename
+              echo $url >> loaded
+            fi
+          done < plugins
+          rm plugins
+        volumeMounts:
+        - mountPath: /plugins
+          name: connect-plugins
+      {{- end }}
       containers:
         {{- if .Values.prometheus.jmx.enabled }}
         - name: prometheus-jmx-exporter
@@ -70,7 +100,7 @@ spec:
                 fieldRef:
                   fieldPath: metadata.name
             - name: CONNECT_PLUGIN_PATH
-              value: {{ template "cp-kafka-connect.pluginPath" }}
+              value: {{ template "cp-kafka-connect.pluginPath" . }}
             - name: CONNECT_BOOTSTRAP_SERVERS
               value: {{ template "cp-kafka-connect.kafka.bootstrapServers" . }}
             - name: CONNECT_GROUP_ID

--- a/charts/cp-kafka-connect/templates/plugins-pvc.yaml
+++ b/charts/cp-kafka-connect/templates/plugins-pvc.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: {{ template "cp-kafka-connect.fullname" . }}-plugins
+spec:
+  accessModes:
+  - ReadWriteMany
+  storageClassName: {{ .Values.pluginVolume.storageClass }}
+  resources:
+    requests:
+      storage: {{ .Values.pluginVolume.size }}

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -27,6 +27,12 @@ connectValueConverter: "io.confluent.connect.avro.AvroConverter"
 connectInternalKeyConverter: "org.apache.kafka.connect.json.JsonConverter"
 connectInternalValueConverter: "org.apache.kafka.connect.json.JsonConverter"
 pluginPath: "/usr/share/java"
+pluginVolume: {}
+#  Enable this to create a persistent volume for storing additional plugins.
+#  enabled: true
+#  storageClass: basic
+#  size: 1Gb
+#  path: "/usr/share/java/custom"
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -33,6 +33,9 @@ pluginVolume: {}
 #  storageClass: basic
 #  size: 1Gi
 #  path: "/usr/share/java/custom"
+downloadPlugins: {}
+#  Download and extract each plugin tar.gz listed
+#  - https://repo1.maven.org/maven2/io/debezium/debezium-connector-mysql/0.8.3.Final/debezium-connector-mysql-0.8.3.Final-plugin.tar.gz
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -31,7 +31,7 @@ pluginVolume: {}
 #  Enable this to create a persistent volume for storing additional plugins.
 #  enabled: true
 #  storageClass: basic
-#  size: 1Gb
+#  size: 1Gi
 #  path: "/usr/share/java/custom"
 
 resources: {}


### PR DESCRIPTION
Added an option to add a volume for plugins in addition to the default ones.  Creates a PVC and adds the path to the CONNECT_PLUGIN_PATH env variable in cp-kafka-connect chart.

(Our use case is to add the debezium plugin.  Maybe in the future we could pass a list of additional plugin URLs to download and extract using an init container instead?  Current method in this pull request does require you to exec into the container and wget/extract the plugin manually)