### PR TITLE
Define broker.rack propery

### DIFF
--- a/charts/cp-kafka/templates/rbac.yaml
+++ b/charts/cp-kafka/templates/rbac.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.rbac.create }}
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: {{ template "cp-kafka.fullname" . }}
+  labels:
+    app: {{ template "cp-kafka.name" . }}
+    chart: {{ template "cp-kafka.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+rules:
+- apiGroups: [""]
+  resources: ["nodes"]
+  verbs: ["get"]
+
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRoleBinding
+metadata:
+  name: {{ template "cp-kafka.fullname" . }}
+  labels:
+    app: {{ template "cp-kafka.name" . }}
+    chart: {{ template "cp-kafka.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: {{ template "cp-kafka.fullname" . }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "cp-kafka.fullname" . }}
+    namespace: {{ .Release.Namespace }}
+{{- end }}

--- a/charts/cp-kafka/templates/serviceaccount.yaml
+++ b/charts/cp-kafka/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "cp-kafka.name" . }}
+    chart: {{ template "cp-kafka.chart" . }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+  name: {{ template "cp-kafka.fullname" . }}
+{{- end }}

--- a/charts/cp-kafka/templates/statefulset.yaml
+++ b/charts/cp-kafka/templates/statefulset.yaml
@@ -25,6 +25,9 @@ spec:
         prometheus.io/port: {{ .Values.prometheus.jmx.port | quote }}
       {{- end }}
     spec:
+      {{- if .Values.serviceAccount.create}}
+      serviceAccountName: {{ template "cp-kafka.fullname" . }}
+      {{- end }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:
@@ -92,6 +95,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: status.hostIP
+        - name: NODE_NAME
+          valueFrom:
+            fieldRef:
+              fieldPath: spec.nodeName
         - name: KAFKA_HEAP_OPTS
           value: {{ .Values.heapOptions }}
         {{- if not (hasKey .Values.configurationOverrides "zookeeper.connect") }}
@@ -120,6 +127,7 @@ spec:
         - |
           export KAFKA_BROKER_ID=${HOSTNAME##*-} && \
           export KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://${POD_IP}:9092{{ if kindIs "string" $advertisedListenersOverride }}{{ printf ",%s" $advertisedListenersOverride }}{{ end }} && \
+          export KAFKA_BROKER_RACK=$(curl -sSk -H "Authorization: Bearer `cat /var/run/secrets/kubernetes.io/serviceaccount/token`" https://kubernetes.default/api/v1/nodes/$NODE_NAME|grep failure-domain.beta.kubernetes.io/zone | sed 's/.*: "\(.*\)",/\1/') && \
           exec /etc/confluent/docker/run
         volumeMounts:
         - name: datadir

--- a/charts/cp-kafka/values.yaml
+++ b/charts/cp-kafka/values.yaml
@@ -105,6 +105,16 @@ nodeport:
   servicePort: 19092
   firstListenerPort: 31090
 
+
+## RBAC configuration
+## Used to get info to set the broker.rack property of the brokers
+serviceAccount:
+  create: true
+
+rbac:
+  create: true
+
+
 ## ------------------------------------------------------
 ## Zookeeper
 ## ------------------------------------------------------


### PR DESCRIPTION

Kubernetes knows the availability zone or `rack` a pod is running on.

We could take this info, which is in the annotation of the node called `failure-domain.beta.kubernetes.io/zone`, and set it as the `broker.rack` property.

AFAIK, That annotation is setup by kube cloud integration's automatically, i.e. on AWS it takes values like `us-east-1c`.
On-Prem, that annotation can be manually set, but not enforced.
In this case the property would be set as:
```broker.rack=```

Not exactly the same as the default `null` value, but close enough as both makes kafka behave the same 😅 

Thanks!!
