### PR TITLE
Allow tests to be run multiple times

### DIFF
--- a/charts/cp-kafka/templates/NOTES.txt
+++ b/charts/cp-kafka/templates/NOTES.txt
@@ -24,6 +24,9 @@ To connect from a client pod:
 
 3. Explore with kafka commands:
 
+  # Delete the topic if it exists
+  kafka-topics --zookeeper {{ template "cp-kafka.cp-zookeeper.service-name" . }} --topic {{ template "cp-kafka.fullname" . }}-topic --delete --if-exists
+
   # Create the topic
   kafka-topics --zookeeper {{ template "cp-kafka.cp-zookeeper.service-name" . }} --topic {{ template "cp-kafka.fullname" . }}-topic --create --partitions 1 --replication-factor 1 --if-not-exists
 
@@ -34,4 +37,4 @@ To connect from a client pod:
   echo "$MESSAGE" | kafka-console-producer --broker-list {{ template "cp-kafka.fullname" . }}:9092 --topic {{ template "cp-kafka.fullname" . }}-topic && \
 
   # Consume a test message from the topic
-  kafka-console-consumer --bootstrap-server {{ template "cp-kafka.fullname" . }}-headless:9092 --topic {{ template "cp-kafka.fullname" . }}-topic --from-beginning --timeout-ms 2000 --max-messages 1 | grep "$MESSAGE"
+  kafka-console-consumer --bootstrap-server {{ template "cp-kafka.fullname" . }}-headless:9092 --topic {{ template "cp-kafka.fullname" . }}-topic --from-beginning --timeout-ms 2000 | grep "$MESSAGE"

--- a/charts/cp-kafka/templates/tests/canary-pod.yaml
+++ b/charts/cp-kafka/templates/tests/canary-pod.yaml
@@ -14,6 +14,8 @@ spec:
     - sh
     - -c
     - |
+      # Delete the topic if it exists
+      kafka-topics --zookeeper {{ template "cp-kafka.cp-zookeeper.service-name" . }} --topic {{ template "cp-kafka.fullname" . }}-canary-topic --delete --if-exists
       # Create the topic
       kafka-topics --zookeeper {{ template "cp-kafka.cp-zookeeper.service-name" . }} --topic {{ template "cp-kafka.fullname" . }}-canary-topic --create --partitions 1 --replication-factor 1 --if-not-exists && \
       # Create a message
@@ -21,5 +23,5 @@ spec:
       # Produce a test message to the topic
       echo "$MESSAGE" | kafka-console-producer --broker-list {{ template "cp-kafka.fullname" . }}:9092 --topic {{ template "cp-kafka.fullname" . }}-canary-topic && \
       # Consume a test message from the topic
-      kafka-console-consumer --bootstrap-server {{ template "cp-kafka.fullname" . }}-headless:9092 --topic {{ template "cp-kafka.fullname" . }}-canary-topic --from-beginning --timeout-ms 2000 --max-messages 1 | grep "$MESSAGE"
+      kafka-console-consumer --bootstrap-server {{ template "cp-kafka.fullname" . }}-headless:9092 --topic {{ template "cp-kafka.fullname" . }}-canary-topic --from-beginning --timeout-ms 2000 | grep "$MESSAGE"
   restartPolicy: Never


### PR DESCRIPTION
This PR improves the tests so that. you can run tests multiple times.

Currently if you attempt to run the tests multiple times, subsequent tests will fail given only a single (i.e. first message) is pulled from the beginning of a pre-existing topic.