### PR TITLE
default JVM memory options should be provided by k8s resources

### DIFF
--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -41,6 +41,11 @@ resources: {}
 jmx:
   port: 5555
 
+## JVM Heap Option
+heapOptions: "-XX:+UnlockExperimentalVMOptions \
+              -XX:+ExitOnOutOfMemoryError \
+              -XX:+UseCGroupMemoryLimitForHeap"
+
 ## Prometheus Exporter Configuration
 ## ref: https://prometheus.io/docs/instrumenting/exporters/
 prometheus:

--- a/charts/cp-kafka-rest/values.yaml
+++ b/charts/cp-kafka-rest/values.yaml
@@ -15,6 +15,11 @@ imagePullPolicy: IfNotPresent
 
 servicePort: 8082
 
+## JVM Heap Option
+heapOptions: "-XX:+UnlockExperimentalVMOptions \
+              -XX:+ExitOnOutOfMemoryError \
+              -XX:+UseCGroupMemoryLimitForHeap"
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/charts/cp-kafka/values.yaml
+++ b/charts/cp-kafka/values.yaml
@@ -64,7 +64,9 @@ persistence:
   # storageClass: ""
 
 ## Kafka JVM Heap Option
-heapOptions: "-Xms1G -Xmx1G"
+heapOptions: "-XX:+UnlockExperimentalVMOptions \
+              -XX:+ExitOnOutOfMemoryError \
+              -XX:+UseCGroupMemoryLimitForHeap"
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/cp-ksql-server/values.yaml
+++ b/charts/cp-ksql-server/values.yaml
@@ -33,6 +33,11 @@ resources: {}
 jmx:
   port: 5555
 
+## JVM Heap Option
+heapOptions: "-XX:+UnlockExperimentalVMOptions \
+              -XX:+ExitOnOutOfMemoryError \
+              -XX:+UseCGroupMemoryLimitForHeap"
+
 ## Prometheus Exporter Configuration
 ## ref: https://prometheus.io/docs/instrumenting/exporters/
 prometheus:

--- a/charts/cp-schema-registry/values.yaml
+++ b/charts/cp-schema-registry/values.yaml
@@ -31,6 +31,11 @@ servicePort: 8081
 kafka:
   bootstrapServers: ""
 
+## Schema Registry JVM Heap Option
+heapOptions: "-XX:+UnlockExperimentalVMOptions \
+              -XX:+ExitOnOutOfMemoryError \
+              -XX:+UseCGroupMemoryLimitForHeap"
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/charts/cp-zookeeper/values.yaml
+++ b/charts/cp-zookeeper/values.yaml
@@ -41,7 +41,9 @@ autoPurgeSnapRetainCount: 3
 autoPurgePurgeInterval: 24
 
 ## Zookeeper JVM Heap Option
-heapOptions: "-Xms512M -Xmx512M"
+heapOptions: "-XX:+UnlockExperimentalVMOptions \
+              -XX:+ExitOnOutOfMemoryError \
+              -XX:+UseCGroupMemoryLimitForHeap"
 
 ## Port
 ## ref: https://zookeeper.apache.org/doc/r3.4.10/zookeeperAdmin.html#sc_configuration


### PR DESCRIPTION
JVM should respect k8s resource spec. Or `cp-docker-images` is better place to implement this?