### PR TITLE
Mount host directories and files

### DIFF
--- a/charts/cp-kafka-connect/README.md
+++ b/charts/cp-kafka-connect/README.md
@@ -145,6 +145,13 @@ The configuration parameters in this section control the resources requested and
 | `prometheus.jmx.imageTag` | Docker Image Tag for Prometheus JMX Exporter container. | `6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143` |
 | `prometheus.jmx.port` | JMX Exporter Port which exposes metrics in Prometheus format for scraping. | `5556` |
 
+### Mount host directories and files
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `hostPaths` | Directories from host to be mount | `[]` |
+| `hostFiles` | Files from host to be mount | `[]` |
+
 ## Dependencies
 
 ### Kafka

--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -101,6 +101,17 @@ spec:
             - name: KAFKA_JMX_PORT
               value: "{{ .Values.jmx.port }}"
             {{- end }}
+          {{- if or .Values.hostPaths .Values.hostFiles }}
+          volumeMounts:
+          {{- range $volume := .Values.hostPaths }}
+            - name: {{ $volume | lower | replace "/" "-" | replace "." "-" | replace "_" "-" | trimAll "-" }}
+              mountPath: {{ $volume }}
+          {{- end }}
+          {{- range $volume := .Values.hostFiles }}
+            - name: {{ $volume | lower | replace "/" "-" | replace "." "-" | replace "_" "-" | trimAll "-" }}
+              mountPath: {{ $volume }}
+          {{- end }}
+          {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
@@ -110,4 +121,16 @@ spec:
       - name: jmx-config
         configMap:
           name: {{ template "cp-kafka-connect.fullname" . }}-jmx-configmap
+      {{- end }}
+      {{- range $volume := .Values.hostPaths }}
+      - name: {{ $volume | lower | replace "/" "-" | replace "." "-" | replace "_" "-" | trimAll "-" }}
+        hostPath:
+          path: {{ $volume }}
+          type: Directory
+      {{- end }}
+      {{- range $volume := .Values.hostFiles }}
+      - name: {{ $volume | lower | replace "/" "-" | replace "." "-" | replace "_" "-" | trimAll "-" }}
+        hostPath:
+          path: {{ $volume }}
+          type: File
       {{- end }}

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -71,3 +71,9 @@ kafka:
 ## e.g. gnoble-panther-cp-schema-registry:8081
 cp-schema-registry:
   url: ""
+
+## Directories from host to be mount
+hostPaths: []
+
+## Files from host to be mount
+hostFiles: []


### PR DESCRIPTION
Signed-off-by: Maciej Bryński <maciej.brynski@xcaliber.com>

Ability to mount directories and files from host.
Can be used to mount HDFS configuration and libraries.
