### PR TITLE
cp-kafka-connect Allow setting the replication factor

### DIFF
--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -97,6 +97,12 @@ spec:
               value: {{ .Values.connectInternalKeyConverter }}
             - name: CONNECT_INTERNAL_VALUE_CONVERTER
               value: {{ .Values.connectInternalValueConverter }}
+            - name: CONNECT_CONFIG_STORAGE_REPLICATION_FACTOR
+              value: "{{ .Values.connectConfigStorageReplicationFactor }}"
+            - name: CONNECT_OFFSET_STORAGE_REPLICATION_FACTOR
+              value: "{{ .Values.connectOffsetStorageReplicationFactor }}"
+            - name: CONNECT_STATUS_STORAGE_REPLICATION_FACTOR
+              value: "{{ .Values.connectStatusStorageReplicationFactor }}"
             {{- if .Values.jmx.port }}
             - name: KAFKA_JMX_PORT
               value: "{{ .Values.jmx.port }}"

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -28,9 +28,9 @@ connectKeyConverterSchemaEnable: false
 connectValueConverterSchemaEnable: false
 connectInternalKeyConverter: "org.apache.kafka.connect.json.JsonConverter"
 connectInternalValueConverter: "org.apache.kafka.connect.json.JsonConverter"
-connectConfigStorageReplicationFactor: 1
-connectOffsetStorageReplicationFactor: 1
-connectStatusStorageReplicationFactor: 1
+connectConfigStorageReplicationFactor: 3
+connectOffsetStorageReplicationFactor: 3
+connectStatusStorageReplicationFactor: 3
 pluginPath: "/usr/share/java"
 
 resources: {}

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -28,6 +28,9 @@ connectKeyConverterSchemaEnable: false
 connectValueConverterSchemaEnable: false
 connectInternalKeyConverter: "org.apache.kafka.connect.json.JsonConverter"
 connectInternalValueConverter: "org.apache.kafka.connect.json.JsonConverter"
+connectConfigStorageReplicationFactor: 1
+connectOffsetStorageReplicationFactor: 1
+connectStatusStorageReplicationFactor: 1
 pluginPath: "/usr/share/java"
 
 resources: {}


### PR DESCRIPTION
Fix for https://github.com/confluentinc/cp-helm-charts/issues/189

Allow setting the replication factor so one can start kafka-connect-server container when there is only 1 broker.