### PR TITLE
Add heaptoptions for connect, ksql and schema-registry

### DIFF
--- a/charts/cp-kafka-connect/README.md
+++ b/charts/cp-kafka-connect/README.md
@@ -110,6 +110,12 @@ The configuration parameters in this section control the resources requested and
 | `configurationOverrides` | Kafka Connect [configuration](https://docs.confluent.io/current/connect/references/allconfigs.html) overrides in the dictionary format. | `{}` |
 | `customEnv` | Custom environmental variables | `{}` |
 
+### Kafka Connect JVM Heap Options
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `heapOptions` | The JVM Heap Options for Kafka Connect | `"-Xms512M -Xmx512M"` |
+
 ### Resources
 
 | Parameter | Description | Default |

--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -83,6 +83,8 @@ spec:
               value: {{ template "cp-kafka-connect.cp-schema-registry.service-name" .}}
             - name: CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL
               value: {{ template "cp-kafka-connect.cp-schema-registry.service-name" .}}
+            - name: KAFKA_HEAP_OPTS
+              value: "{{ .Values.heapOptions }}"
             {{- range $key, $value := .Values.configurationOverrides }}
             - name: {{ printf "CONNECT_%s" $key | replace "." "_" | upper | quote }}
               value: {{ $value | quote }}

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -34,6 +34,9 @@ configurationOverrides:
   "offset.storage.replication.factor": "3"
   "status.storage.replication.factor": "3"
 
+## Kafka Connect JVM Heap Option
+heapOptions: "-Xms512M -Xmx512M"
+
 ## Additional env variables
 customEnv: {}
 

--- a/charts/cp-kafka-rest/README.md
+++ b/charts/cp-kafka-rest/README.md
@@ -114,6 +114,12 @@ The configuration parameters in this section control the resources requested and
 | --------- | ----------- | ------- |
 | `configurationOverrides` | Kafka REST [configuration](https://docs.confluent.io/current/kafka-rest/docs/config.html) overrides in the dictionary format | `{}` |
 
+### Confluent Kafka REST JVM Heap Options
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `heapOptions` | The JVM Heap Options for Confluent Kafka REST | `"-Xms512M -Xmx512M"` |
+
 ### Resources
 
 | Parameter | Description | Default |

--- a/charts/cp-kafka-rest/templates/deployment.yaml
+++ b/charts/cp-kafka-rest/templates/deployment.yaml
@@ -73,6 +73,8 @@ spec:
             value: {{ template "cp-kafka-rest.cp-zookeeper.service-name" . }}
           - name: KAFKA_REST_SCHEMA_REGISTRY_URL
             value: {{ template "cp-kafka-rest.cp-schema-registry.service-name" . }}
+          - name: KAFKAREST_HEAP_OPTS
+            value: "{{ .Values.heapOptions }}"
           {{- range $key, $value := .Values.configurationOverrides }}
           - name: {{ printf "KAFKA_REST_%s" $key | replace "." "_" | upper | quote }}
             value: {{ $value | quote }}

--- a/charts/cp-kafka-rest/values.yaml
+++ b/charts/cp-kafka-rest/values.yaml
@@ -20,6 +20,9 @@ imagePullSecrets:
 
 servicePort: 8082
 
+## Kafka rest JVM Heap Option
+heapOptions: "-Xms512M -Xmx512M"
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/charts/cp-kafka/README.md
+++ b/charts/cp-kafka/README.md
@@ -146,7 +146,7 @@ The configuration parameters in this section control the resources requested and
 
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
-| `heapOptions` | The JVM Heap Options for Kafka | `"-Xms1G -Xmx1G"` |
+| `heapOptions` | The JVM Heap Options for Kafka | `"-Xms512M -Xmx512M"` |
 
 ### Resources
 

--- a/charts/cp-kafka/values.yaml
+++ b/charts/cp-kafka/values.yaml
@@ -73,7 +73,7 @@ persistence:
   disksPerBroker: 1
 
 ## Kafka JVM Heap Option
-heapOptions: "-Xms1G -Xmx1G"
+heapOptions: "-Xms512M -Xmx512M"
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious

--- a/charts/cp-ksql-server/README.md
+++ b/charts/cp-ksql-server/README.md
@@ -123,6 +123,12 @@ The configuration parameters in this section control the resources requested and
 | --------- | ----------- | ------- |
 | `servicePort` | The port on which the KSQL Server will be available and serving requests. | `8088` |
 
+### KSQL JVM Heap Options
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `heapOptions` | The JVM Heap Options for KSQL | `"-Xms512M -Xmx512M"` |
+
 ### Resources
 
 | Parameter | Description | Default |

--- a/charts/cp-ksql-server/templates/deployment.yaml
+++ b/charts/cp-ksql-server/templates/deployment.yaml
@@ -76,6 +76,8 @@ spec:
             value: {{ template "cp-ksql-server.serviceId" . }}
           - name: KSQL_KSQL_SCHEMA_REGISTRY_URL
             value: {{ template "cp-ksql-server.cp-schema-registry.service-name" . }}
+          - name: KSQL_HEAP_OPTS
+            value: "{{ .Values.heapOptions }}"
           {{- if .Values.ksql.headless }}
           - name: KSQL_KSQL_QUERIES_FILE
             value: /etc/ksql/queries/queries.sql

--- a/charts/cp-ksql-server/values.yaml
+++ b/charts/cp-ksql-server/values.yaml
@@ -20,6 +20,9 @@ imagePullSecrets:
 
 servicePort: 8088
 
+## KSQL JVM Heap Option
+heapOptions: "-Xms512M -Xmx512M"
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/charts/cp-schema-registry/README.md
+++ b/charts/cp-schema-registry/README.md
@@ -118,6 +118,12 @@ The configuration parameters in this section control the resources requested and
 | --------- | ----------- | ------- |
 | `kafka.bootstrapServers` | Bootstrap Servers for Schema Registry | `""` |
 
+### Confluent Schema Registry JVM Heap Options
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `heapOptions` | The JVM Heap Options for Confluent Schema Registry | `"-Xms512M -Xmx512M"` |
+
 ### Resources
 
 | Parameter | Description | Default |

--- a/charts/cp-schema-registry/templates/deployment.yaml
+++ b/charts/cp-schema-registry/templates/deployment.yaml
@@ -77,6 +77,8 @@ spec:
             value: {{ template "cp-schema-registry.groupId" . }}
           - name: SCHEMA_REGISTRY_MASTER_ELIGIBILITY
             value: "true"
+          - name: SCHEMA_REGISTRY_HEAP_OPTS
+            value: "{{ .Values.heapOptions }}"
           {{ range $configName, $configValue := .Values.configurationOverrides }}
           - name: SCHEMA_REGISTRY_{{ $configName | replace "." "_" | upper }}
             value: {{ $configValue | quote }}

--- a/charts/cp-schema-registry/values.yaml
+++ b/charts/cp-schema-registry/values.yaml
@@ -33,6 +33,9 @@ customEnv: {}
 ## The port on which the Schema Registry will be available and serving requests
 servicePort: 8081
 
+## Schema registry JVM Heap Option
+heapOptions: "-Xms512M -Xmx512M"
+
 ## You can list load balanced service endpoint, or list of all brokers (which is hard in K8s).  e.g.:
 ## bootstrapServers: "PLAINTEXT://dozing-prawn-kafka-headless:9092"
 ## Charts uses Kafka Coordinator Master Election: https://docs.confluent.io/current/schema-registry/docs/design.html#kafka-coordinator-master-election

--- a/values.yaml
+++ b/values.yaml
@@ -94,6 +94,7 @@ cp-kafka-rest:
   ## https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
   imagePullSecrets:
   #  - name: "regcred"
+  heapOptions: "-Xms512M -Xmx512M"
   resources: {}
   ## If you do want to specify resources, uncomment the following lines, adjust them as necessary,
   ## and remove the curly braces after 'resources:'
@@ -115,6 +116,7 @@ cp-kafka-connect:
   ## https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
   imagePullSecrets:
   #  - name: "regcred"
+  heapOptions: "-Xms512M -Xmx512M"
   resources: {}
   ## If you do want to specify resources, uncomment the following lines, adjust them as necessary,
   ## and remove the curly braces after 'resources:'
@@ -136,5 +138,6 @@ cp-ksql-server:
   ## https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
   imagePullSecrets:
   #  - name: "regcred"
+  heapOptions: "-Xms512M -Xmx512M"
   ksql:
     headless: false


### PR DESCRIPTION
As per: https://github.com/confluentinc/cp-helm-charts/issues/130

Would like some feedback for the defaults.