### PR TITLE
Revert to old behaviour when having only one disk

### DIFF
--- a/charts/cp-kafka/templates/_helpers.tpl
+++ b/charts/cp-kafka/templates/_helpers.tpl
@@ -59,8 +59,13 @@ Create a variable containing all the datadirs created.
 */}}
 
 {{- define "cp-kafka.log.dirs" -}}
-{{- range $k, $e := until (.Values.persistence.disksPerBroker|int) -}}
+{{- printf "/opt/kafka/data/logs" -}}
+{{- $extradisksPerBroker := (sub $.Values.persistence.disksPerBroker 1 | int) }}
+{{- if not (eq 0 $extradisksPerBroker )}}
+{{- printf ","}}
+{{- range $k, $e := until $extradisksPerBroker }}
 {{- if $k}}{{- printf ","}}{{end}}
 {{- printf "/opt/kafka/data-%d/logs" $k -}}
+{{- end -}}
 {{- end -}}
 {{- end -}}

--- a/charts/cp-kafka/templates/statefulset.yaml
+++ b/charts/cp-kafka/templates/statefulset.yaml
@@ -127,10 +127,14 @@ spec:
           export KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://${POD_IP}:9092{{ if kindIs "string" $advertisedListenersOverride }}{{ printf ",%s" $advertisedListenersOverride }}{{ end }} && \
           exec /etc/confluent/docker/run
         volumeMounts:
-        {{- $disksPerBroker := .Values.persistence.disksPerBroker | int }}
-        {{- range $k, $e := until $disksPerBroker }}
+        - name: datadir
+          mountPath: /opt/kafka/data
+        {{- $extradisksPerBroker := (sub $.Values.persistence.disksPerBroker 1 | int) }}
+        {{- if not (eq 0 $extradisksPerBroker )}}
+        {{- range $k, $e := until $extradisksPerBroker }}
         - name: datadir-{{$k}}
           mountPath: /opt/kafka/data-{{$k}}
+        {{- end }}
         {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -156,22 +160,38 @@ spec:
       {{- end }}
   {{- if .Values.persistence.enabled }}
   volumeClaimTemplates:
-  {{- $disksPerBroker := .Values.persistence.disksPerBroker | int }}
+    - metadata:
+        name: datadir
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: "{{ .Values.persistence.size }}"
+        {{- if .Values.persistence.storageClass }}
+        {{- if (eq "-" .Values.persistence.storageClass) }}
+        storageClassName: ""
+        {{- else }}
+        storageClassName: "{{ .Values.persistence.storageClass }}"
+        {{- end }}
+        {{- end }}
+  {{- $extradisksPerBroker := (sub $.Values.persistence.disksPerBroker 1 | int) }}
+  {{- if not (eq 0 $extradisksPerBroker )}}
   {{- $root := . }}
-  {{- range $k, $e := until $disksPerBroker }}
-  - metadata:
-      name: datadir-{{$k}}
-    spec:
-      accessModes: [ "ReadWriteOnce" ]
-      resources:
-        requests:
-          storage: "{{ $root.Values.persistence.size }}"
-      {{- if $root.Values.persistence.storageClass }}
-      {{- if (eq "-" $root.Values.persistence.storageClass) }}
-      storageClassName: ""
-      {{- else }}
-      storageClassName: "{{ $root.Values.persistence.storageClass }}"
-      {{- end }}
-      {{- end }}
-{{- end }}
+  {{- range $k, $e := until $extradisksPerBroker }}
+    - metadata:
+        name: datadir-{{$k}}
+      spec:
+        accessModes: [ "ReadWriteOnce" ]
+        resources:
+          requests:
+            storage: "{{ $root.Values.persistence.size }}"
+        {{- if $root.Values.persistence.storageClass }}
+        {{- if (eq "-" $root.Values.persistence.storageClass) }}
+        storageClassName: ""
+        {{- else }}
+        storageClassName: "{{ $root.Values.persistence.storageClass }}"
+        {{- end }}
+        {{- end }}
+  {{- end }}
+  {{- end}}
 {{- end }}


### PR DESCRIPTION
Avoid breaking current deployments by keeping names the same for first disk.
Mitigates: https://github.com/confluentinc/cp-helm-charts/issues/214