### PR TITLE
Add 'heapOptions' config to Kafka Connect chart

### DIFF
--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -95,6 +95,10 @@ spec:
             - name: KAFKA_JMX_PORT
               value: "{{ .Values.jmx.port }}"
             {{- end }}
+            {{- if .Values.heapOptions }}
+            - name: KAFKA_HEAP_OPTS
+              value: "{{ .Values.heapOptions }}"
+            {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -37,6 +37,9 @@ configurationOverrides:
 ## Additional env variables
 customEnv: {}
 
+## Kafka Connect JVM Heap Options
+heapOptions:
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adds the `heapOptions` config to the Kafka Connect chart.

This allows for overriding the default values, which result in OOM killed pods when pod resource limits are set below that of the defaults (e.g. setting a pod limit to 1gb along side the default 2gb max heap). 

## How was this patch tested?

helm install to k8s kops cluster running on AWS (not EKS).
