### PR TITLE
ST-1284: Run lint for PR and on commit

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,11 @@
+def config = jobConfig {
+    slackChannel = 'tools-eng'  // TODO: Change this when Viktor provides one
+}
+
+def job = {
+    stage('Lint') {
+        sh 'scripts/lint.sh'
+    }
+}
+
+runJob config, job

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -1,0 +1,11 @@
+if [ -t 1 ] ; then
+  RED='\033[0;31m'
+  GREEN='\033[0;32m'
+  BLUE='\033[0;34m'
+  RS='\033[0m' # reset to no color
+else
+  RED=''
+  GREEN=''
+  BLUE=''
+  RS=''
+fi

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -1,8 +1,6 @@
 #!/bin/bash
-error=0
-RED='\033[0;31m'
-RS='\033[0m' # No Color
-GREEN='\033[0;32m'
+
+. scripts/common.sh
 
 echo -e "==> ${GREEN}Linting cp-helm-charts..${RS}."
 
@@ -18,5 +16,3 @@ for chart in `ls -1 charts`; do
   echo -e "$output" | grep "\\["
 done
 echo -e "==> ${GREEN} No linting errors${RS}"
-
-exit $error

--- a/scripts/lint.sh
+++ b/scripts/lint.sh
@@ -2,17 +2,31 @@
 
 . scripts/common.sh
 
-echo -e "==> ${GREEN}Linting cp-helm-charts..${RS}."
+function lint_chart() {
+  chart_name=$1
+  chart_file=$2
 
-for chart in `ls -1 charts`; do
-  echo -e "==> ${GREEN}Linting $chart...${RS}"
-  #output=`helm lint . --debug --strict 2> /dev/null`
-  output=`helm lint . --debug 2> /dev/null`
+  echo -e "==> ${GREEN}Linting $chart_name...${RS}"
+  output=`helm lint $chart_file --debug 2> /dev/null`
   if [ $? -ne 0 ]; then
-    echo -e "===> ${RED} Liniting errors for chart $chart ${RS}"
+    echo -e "===> ${RED} Linting errors for chart $chart_name ${RS}"
     echo -e "$output" | grep "\\["
     exit 1
   fi
   echo -e "$output" | grep "\\["
+}
+
+# Jenkins's working dir is not cp-helm-charts, so copy to tmp dir before linting
+if [[ $JENKINS_HOME ]]; then
+  rm -rf /tmp/cp-helm-charts
+  cp -R . /tmp/cp-helm-charts
+  cd /tmp/cp-helm-charts
+fi
+
+lint_chart cp-helm-charts .
+
+for chart in `ls -1 charts`; do
+  lint_chart $chart charts/$chart
 done
+
 echo -e "==> ${GREEN} No linting errors${RS}"

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -1,8 +1,6 @@
 #!/usr/bin/env bash
-RED='\033[0;31m'
-GREEN='\033[0;32m'
-BLUE='\033[0;34m'
-RS='\033[0m' # reset
+
+. scripts/common.sh
 
 echo -e "${RS}${BLUE} Cleaning and preparing..."
 find . -iname "*.tgz" -type f | grep -v 'docs/' | xargs rm


### PR DESCRIPTION
Note this depends on https://github.com/confluentinc/confluent-docker-build-images/pull/41 that install `helm` script and so this PR will fail until our Jenkins slave image is updated (blocked on an unrelated failure for another image). 

For PR build, it will run lint. Once checked in, it runs package (which includes lint) to produce a local package. We will add publishing to Artifactory in a future PR.  

@gAmUssA Some outstanding questions for you:
1) Where should build notifications go to?
2) How should this be versioned per commit? We can work on this in a future PR
3) Where should artifacts be stored after running `helm package`? Docs seems like an odd place, so moving to build dir. But that's not consistent with the comment at the end of the package.sh script. 
4) Deleting the previously built artifacts in docs as they were checked in? 