### PR TITLE
Fix resolving ZK hostname upon starting

### DIFF
--- a/charts/cp-zookeeper/templates/statefulset.yaml
+++ b/charts/cp-zookeeper/templates/statefulset.yaml
@@ -115,7 +115,11 @@ spec:
         command:
         - "bash"
         - "-c"
-        - "ZOOKEEPER_SERVER_ID=$((${HOSTNAME##*-}+1)) && /etc/confluent/docker/run"
+        - |
+          ZK_FIX_HOST_REGEX="s/${HOSTNAME}\.[^:]*:/0.0.0.0:/g"
+          ZOOKEEPER_SERVER_ID=$((${HOSTNAME##*-}+1)) \
+          ZOOKEEPER_SERVERS=`echo $ZOOKEEPER_SERVERS | sed -e "$ZK_FIX_HOST_REGEX"` \
+          /etc/confluent/docker/run
         volumeMounts:
         - name: datadir
           mountPath: /var/lib/zookeeper/data


### PR DESCRIPTION
## What changes were proposed in this pull request?

Change ZK hostname to 0.0.0.0 on each instance so it is able to resolve itself in case there is a delay in kube-router DNS propagation. Otherwise, after few attempts, ZK stops attempting to resolve its own host and doesn't work properly.

I posted more details in this issue: https://github.com/confluentinc/cp-helm-charts/issues/205#issuecomment-447001502

## How was this patch tested?

Tested on our QA and stage environments using `helm install`. At least one more person had luck with this fix (refer to the above issue).