### PR TITLE
Add minimum required config for KSQL to connect to Confluent Cloud

### DIFF
--- a/charts/cp-ksql-server/values.yaml
+++ b/charts/cp-ksql-server/values.yaml
@@ -87,5 +87,12 @@ cp-schema-registry:
 
 # KSQL configuration options
 ## ref: https://docs.confluent.io/current/ksql/docs/installation/server-config/config-reference.html
+## ref: https://docs.confluent.io/current/ksql/docs/installation/server-config/security.html
 configurationOverrides: {}
   # "ksql.streams.producer.retries": "2147483647"
+  # "ksql.sink.replicas": "3"
+  # "ksql.streams.replication.factor": "3"
+  # "listeners": "http://0.0.0.0:8088"
+  # "security.protocol": "SASL_SSL"
+  # "sasl.mechanism": "PLAIN"
+  # "sasl.jaas.config": "org.apache.kafka.common.security.plain.PlainLoginModule required username=\"test\" password=\"testpassword\";"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add example parameters for: 

- ksql.sink.replicas
- ksql.streams.replication.factor
- listeners
- security.protocol
- sasl.jaas.config

## How was this patch tested?

1. Uncommented the relevant configurationOverrides parameters and filled in with real values
2. set headless parameter to false
2. helm install on gke
4. Attached KSQL CLI to KSQL in GKE
5. Verified KSQL connection to Confluent Cloud Kafka
