### PR TITLE
Change template partial cp-zookeeper.service-name to cp-zookeeper.connect

### DIFF
--- a/charts/cp-kafka-rest/templates/_helpers.tpl
+++ b/charts/cp-kafka-rest/templates/_helpers.tpl
@@ -37,7 +37,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "cp-kafka-rest.cp-zookeeper.fullname" -}}
 {{- $name := default "cp-zookeeper" (index .Values "cp-zookeeper" "nameOverride") -}}
-{{- printf "%s-%s-headless" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
@@ -48,7 +48,7 @@ else use user-provided URL
 {{- if (index .Values "cp-zookeeper" "url") -}}
 {{- printf "%s" (index .Values "cp-zookeeper" "url") }}
 {{- else -}}
-{{- printf "%s:2181" (include "cp-kafka-rest.cp-zookeeper.fullname" .) }}
+{{- printf "%s-headless:2181" (include "cp-kafka-rest.cp-zookeeper.fullname" .) }}
 {{- end -}}
 {{- end -}}
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Very small change: cp-kafka chart adds the `-headless` suffix for the Zookeeper connection string in `cp-zookeeper.service-name`, and cp-kafka-rest chart adds the suffix in `cp-zookeeper.fullname`. I think it's more intuitive to append `-headless` in `cp-zookeeper.service-name`, and it is a little confusing to have it appended in different places in the two charts. This PR changes the cp-kafka-rest partials to match those in cp-kafka.

## How was this patch tested?

`helm install` on GKE