### PR TITLE
Allow cp-kafka and cp-kafka-rest to use differently configured Zookeeper clientPort

### DIFF
--- a/charts/cp-kafka-rest/templates/_helpers.tpl
+++ b/charts/cp-kafka-rest/templates/_helpers.tpl
@@ -48,7 +48,8 @@ else use user-provided URL
 {{- if (index .Values "cp-zookeeper" "url") -}}
 {{- printf "%s" (index .Values "cp-zookeeper" "url") }}
 {{- else -}}
-{{- printf "%s:2181" (include "cp-kafka-rest.cp-zookeeper.fullname" .) }}
+{{- $clientPort := default 2181 (index .Values "cp-zookeeper" "clientPort") | int -}}
+{{- printf "%s:%d" (include "cp-kafka-rest.cp-zookeeper.fullname" .) $clientPort }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/cp-kafka/templates/_helpers.tpl
+++ b/charts/cp-kafka/templates/_helpers.tpl
@@ -46,7 +46,8 @@ else use user-provided URL
 */}}
 {{- define "cp-kafka.cp-zookeeper.service-name" }}
 {{- if (index .Values "cp-zookeeper" "enabled") -}}
-{{- printf "%s-headless:2181" (include "cp-kafka.cp-zookeeper.fullname" .) }}
+{{- $clientPort := default 2181 (index .Values "cp-zookeeper" "clientPort") | int -}}
+{{- printf "%s:%d" (include "cp-kafka.cp-zookeeper.fullname" .) $clientPort }}
 {{- else -}}
 {{- $zookeeperConnect := printf "%s" (index .Values "cp-zookeeper" "url") }}
 {{- $zookeeperConnectOverride := (index .Values "configurationOverrides" "zookeeper.connect") }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

`clientPort` is configurable in the Zookeeper chart, but if it is installed alongside the `cp-kafka` and `cp-kafka-rest` charts the Zookeeper connect URL defaults to `2181` without allowing for configuration. This change allows both charts to set the Zookeeper client port but still default to 2181 if none is given.

## How was this patch tested?

Change `values.yaml` for affected charts to include `clientPort` and `helm install --dry-run` to ensure that the Zookeeper connect URL was changed accordingly.
`helm install --dry-run` with original `values.yaml` to ensure that Zookeeper connect URL defaults to port 2181.