### PR TITLE
Add ability to configure zookeeper chroot for installations of cp-kafka and cp-kafka-rest alongside cp-zookeeper

### DIFF
--- a/charts/cp-kafka-rest/templates/_helpers.tpl
+++ b/charts/cp-kafka-rest/templates/_helpers.tpl
@@ -48,7 +48,8 @@ else use user-provided URL
 {{- if (index .Values "cp-zookeeper" "url") -}}
 {{- printf "%s" (index .Values "cp-zookeeper" "url") }}
 {{- else -}}
-{{- printf "%s:2181" (include "cp-kafka-rest.cp-zookeeper.fullname" .) }}
+{{- $chroot := default "" .Values.zkChroot -}}
+{{- printf "%s:2181%s" (include "cp-kafka-rest.cp-zookeeper.fullname" .) $chroot }}
 {{- end -}}
 {{- end -}}
 

--- a/charts/cp-kafka/templates/_helpers.tpl
+++ b/charts/cp-kafka/templates/_helpers.tpl
@@ -46,7 +46,8 @@ else use user-provided URL
 */}}
 {{- define "cp-kafka.cp-zookeeper.service-name" }}
 {{- if (index .Values "cp-zookeeper" "enabled") -}}
-{{- printf "%s-headless:2181" (include "cp-kafka.cp-zookeeper.fullname" .) }}
+{{- $chroot := default "" .Values.zkChroot -}}
+{{- printf "%s-headless:2181%s" (include "cp-kafka.cp-zookeeper.fullname" .) $chroot }}
 {{- else -}}
 {{- $zookeeperConnect := printf "%s" (index .Values "cp-zookeeper" "url") }}
 {{- $zookeeperConnectOverride := (index .Values "configurationOverrides" "zookeeper.connect") }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

When the cp-zookeeper chart is installed alongside cp-kafka and cp-kafka-rest, users cannot configure the chroot for Zookeeper. This patch allows users to configure an optional chroot for Zookeeper, e.g. `/kafka`.

## How was this patch tested?

- `helm install --dry-run` to ensure that ZK connection string defaults to no chroot
- Add `zkChroot: /kafka` to `values.yaml` and `helm install --dry-run` to ensure that ZK connection string is amended to include chroot
- Installation on GKE
