### PR TITLE
fixed helm repo add command in docs

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -104,7 +104,7 @@ Clone the Confluent Helm Chart repo
 
 .. code:: sh
 
-      > helm repo add confluent https://confluentinc.github.io/cp-helm-charts/
+      > helm repo add confluentinc https://confluentinc.github.io/cp-helm-charts/
     "confluentinc" has been added to your repositories
 
       > helm repo update


### PR DESCRIPTION
## What changes were proposed in this pull request?

fixed "helm repo add" command to use "confluentinc" as namespace

## How was this patch tested?

manually tested command
