### PR TITLE
DOCS-1239: fix link to grafana dashboard

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -337,7 +337,7 @@ Exporter is installed as a sidecar container along with all Pods.
 2. Add Prometheus as Data Source in Grafana, url should be something
    like: ``http://illmannered-marmot-prometheus-server:9090``
 
-3. Import dashboard under `grafana-dashboard <grafana-dashboard>`__ into
+3. Import dashboard under `grafana-dashboard <https://github.com/confluentinc/cp-helm-charts/blob/master/grafana-dashboard/confluent-open-source-grafana-dashboard.json>`__ into
    Grafana |Kafka Dashboard|
 
    .. figure:: ../screenshots/zookeeper.png


### PR DESCRIPTION
## What changes were proposed in this pull request?

link to grafana dashboard
https://confluentcommunity.slack.com/archives/CAH4V63RN/p1549577976050700 

## How was this patch tested?

rst doc preview