### PR TITLE
Add optional ability to define custom rules for Prometheus JMX Exporter

### DIFF
--- a/charts/cp-kafka-connect/templates/jmx-configmap.yaml
+++ b/charts/cp-kafka-connect/templates/jmx-configmap.yaml
@@ -26,4 +26,7 @@ data:
         connector: $1
         task: $2
         status: $3
+    {{- if .Values.prometheus.jmx.customRules }}
+{{ toYaml .Values.prometheus.jmx.customRules | indent 4 }}
+    {{- end }}
 {{- end }}

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -84,6 +84,17 @@ prometheus:
     ## See the `resources` documentation above for details.
     resources: {}
 
+    ## Custom rules for Prometheus Exporter. To add your own rules, remove [] after 'customRules'.
+    ## Example format:
+    ## - pattern : "kafka.connect<type=connector-task-metrics, connector=([^:]+), task=([^:]+)><>status: ([^:]+)"
+    ##   name: "cp_kafka_connect_connect_connector_metrics"
+    ##   value: 1
+    ##   labels:
+    ##     connector: $1
+    ##     task: $2
+    ##     status: $3
+    customRules: []
+
 ## You can list load balanced service endpoint, or list of all brokers (which is hard in K8s).  e.g.:
 ## bootstrapServers: "PLAINTEXT://dozing-prawn-kafka-headless:9092"
 kafka:

--- a/charts/cp-kafka-rest/templates/jmx-configmap.yaml
+++ b/charts/cp-kafka-rest/templates/jmx-configmap.yaml
@@ -19,4 +19,7 @@ data:
       name: "cp_kafka_rest_jetty_metrics_$1"
     - pattern : 'kafka.rest<type=jersey-metrics>([^:]+):'
       name: "cp_kafka_rest_jersey_metrics_$1"
+    {{- if .Values.prometheus.jmx.customRules }}
+{{ toYaml .Values.prometheus.jmx.customRules | indent 4 }}
+    {{- end }}
 {{- end }}

--- a/charts/cp-kafka-rest/values.yaml
+++ b/charts/cp-kafka-rest/values.yaml
@@ -72,6 +72,12 @@ prometheus:
     ## See the `resources` documentation above for details.
     resources: {}
 
+    ## Custom rules for Prometheus Exporter. To add your own rules, remove [] after 'customRules'.
+    ## Example format:
+    ## - pattern : 'kafka.rest<type=jersey-metrics>([^:]+):'
+    ##   name: "cp_kafka_rest_jersey_metrics_$1"
+    customRules: []
+
 ## External Access
 ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
 external:

--- a/charts/cp-kafka/templates/jmx-configmap.yaml
+++ b/charts/cp-kafka/templates/jmx-configmap.yaml
@@ -33,4 +33,7 @@ data:
       name: "cp_kafka_controller_controllerstats_$1"
     - pattern : kafka.server<type=SessionExpireListener, name=(.+)><>OneMinuteRate
       name: "cp_kafka_server_sessionexpirelistener_$1"
+    {{- if .Values.prometheus.jmx.customRules }}
+{{ toYaml .Values.prometheus.jmx.customRules | indent 4 }}
+    {{- end }}
 {{- end }}

--- a/charts/cp-kafka/values.yaml
+++ b/charts/cp-kafka/values.yaml
@@ -120,6 +120,14 @@ prometheus:
     ## See the `resources` documentation above for details.
     resources: {}
 
+    ## Custom rules for Prometheus Exporter. To add your own rules, remove [] after 'customRules'.
+    ## Example format:
+    ## - pattern : kafka.server<type=ReplicaManager, name=(.+)><>(Value|OneMinuteRate)
+    ##   name: "cp_kafka_server_replicamanager_$1"
+    ## - pattern : kafka.controller<type=KafkaController, name=(.+)><>Value
+    ##   name: "cp_kafka_controller_kafkacontroller_$1"
+    customRules: []
+
 nodeport:
   enabled: false
   servicePort: 19092

--- a/charts/cp-ksql-server/templates/jmx-configmap.yaml
+++ b/charts/cp-ksql-server/templates/jmx-configmap.yaml
@@ -17,4 +17,7 @@ data:
     rules:
     - pattern : 'io.confluent.ksql.metrics<type=ksql-engine-query-stats>([^:]+):'
       name: "cp_ksql_server_metrics_$1"
+    {{- if .Values.prometheus.jmx.customRules }}
+{{ toYaml .Values.prometheus.jmx.customRules | indent 4 }}
+    {{- end }}
 {{- end }}

--- a/charts/cp-ksql-server/values.yaml
+++ b/charts/cp-ksql-server/values.yaml
@@ -67,6 +67,12 @@ prometheus:
     ## See the `resources` documentation above for details.
     resources: {}
 
+    ## Custom rules for Prometheus Exporter. To add your own rules, remove [] after 'customRules'.
+    ## Example format:
+    ## - pattern : 'io.confluent.ksql.metrics<type=ksql-engine-query-stats>([^:]+):'
+    ##   name: "cp_ksql_server_metrics_$1"
+    customRules: []
+
 ## External Access
 ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
 external:

--- a/charts/cp-schema-registry/templates/jmx-configmap.yaml
+++ b/charts/cp-schema-registry/templates/jmx-configmap.yaml
@@ -21,4 +21,7 @@ data:
       name: "cp_kafka_schema_registry_master_slave_role"
     - pattern : 'kafka.schema.registry<type=jersey-metrics>([^:]+):'
       name: "cp_kafka_schema_registry_jersey_metrics_$1"
+    {{- if .Values.prometheus.jmx.customRules }}
+{{ toYaml .Values.prometheus.jmx.customRules | indent 4 }}
+    {{- end }}
 {{- end }}

--- a/charts/cp-schema-registry/values.yaml
+++ b/charts/cp-schema-registry/values.yaml
@@ -81,5 +81,10 @@ prometheus:
     image: solsson/kafka-prometheus-jmx-exporter@sha256
     imageTag: 6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143
     port: 5556
-
     resources: {}
+
+    ## Custom rules for Prometheus Exporter. To add your own rules, remove [] after 'customRules'.
+    ## Example format:
+    ## - pattern : 'kafka.schema.registry<type=jersey-metrics>([^:]+):'
+    ##   name: "cp_kafka_schema_registry_jersey_metrics_$1"
+    customRules: []

--- a/charts/cp-zookeeper/templates/jmx-configmap.yaml
+++ b/charts/cp-zookeeper/templates/jmx-configmap.yaml
@@ -31,4 +31,7 @@ data:
       labels:
         replicaId: "$2"
         memberType: "$3"
+    {{- if .Values.prometheus.jmx.customRules }}
+{{ toYaml .Values.prometheus.jmx.customRules | indent 4 }}
+    {{- end }}
 {{- end }}

--- a/charts/cp-zookeeper/values.yaml
+++ b/charts/cp-zookeeper/values.yaml
@@ -116,3 +116,11 @@ prometheus:
     ## Resources configuration for the JMX exporter container.
     ## See the `resources` documentation above for details.
     resources: {}
+
+    ## Custom rules for Prometheus Exporter. To add your own rules, remove [] after 'customRules'.
+    ## Example format:
+    ## - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+), name1=replica.(\\d+)><>(\\w+)"
+    ##   name: "cp_zookeeper_$3"
+    ##   labels:
+    ##    replicaId: "$2"
+    customRules: []


### PR DESCRIPTION
## What changes were proposed in this pull request?

Adds a new configuration, `prometheus.jmx.customRules`, that allows users to define custom rules for the Prometheus JMX exporter. This was added to all charts. Defaults to an empty array.

Limitations: `toYaml` removes all quotes from strings, so patterns, descriptions, etc. should not contain any reserved characters that are not allowed in plain scalars in YAML, for example ": ". I considered a workaround, but `toYaml` felt simpler to use and understand (and is used in other places in the codebase). For our use case we are not particularly worried about reserved character combinations. If this does not work I am happy to reexamine.

## How was this patch tested?

Ran `helm install --dry-run` on GKE with some custom metrics to confirm that they were included. Ran `helm upgrade` on a GKE cluster to add custom metrics for an existing cluster. Also ran a dry run without any custom metrics defined to confirm that the output configmap looked as expected.