### PR TITLE
Correct Zookeeper headless service name in Kafka helpers

### DIFF
--- a/charts/cp-kafka/templates/_helpers.tpl
+++ b/charts/cp-kafka/templates/_helpers.tpl
@@ -37,7 +37,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 */}}
 {{- define "cp-kafka.cp-zookeeper.fullname" -}}
 {{- $name := default "cp-zookeeper" (index .Values "cp-zookeeper" "nameOverride") -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-%s-headless" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
## What changes were proposed in this pull request?

In a previous PR that was accepted I accidentally removed `headless` from the `cp-kafka` template helper. This is my fault -- I apologize for the mistake. I was following the pattern in `cp-kafka-rest`, which was slightly different from this one, and I had intended to submit a PR to align them but did not get around to it.

This PR adds `-headless` to the `fullname` helper in `cp-kafka` which matches it with `cp-kafka-rest` and restores previous functionality.

## How was this patch tested?

Helm dry-run to inspect output; `helm upgrade --install` on a GKE cluster.