### PR TITLE
Add health checks for zookeeper statefulset

### DIFF
--- a/charts/cp-zookeeper/templates/statefulset.yaml
+++ b/charts/cp-zookeeper/templates/statefulset.yaml
@@ -125,6 +125,18 @@ spec:
           mountPath: /var/lib/zookeeper/data
         - name: datalogdir
           mountPath: /var/lib/zookeeper/log
+        {{- if eq .Values.podManagementPolicy "Parallel" }}
+        readinessProbe:
+          tcpSocket:
+            port: client
+            initialDelaySeconds: {{ .Values.clientReadiness.initialDelaySeconds }}
+            periodSeconds: 2
+        livenessProbe:
+          tcpSocket:
+            port: client
+          initialDelaySeconds: {{ .Values.clientLiveness.initialDelaySeconds }}
+          periodSeconds: 2
+        {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}

--- a/charts/cp-zookeeper/values.yaml
+++ b/charts/cp-zookeeper/values.yaml
@@ -29,7 +29,9 @@ imagePullSecrets:
 ## StatefulSet Config
 ## Start and stop pods in Parallel or OrderedReady (one-by-one.)
 ## ref: https://kubernetes.io/docs/tutorials/stateful-application/basic-stateful-set/#pod-management-policy
-podManagementPolicy: OrderedReady
+## Only parallel policy can be used, if health checks are enabled. Otherwise, the quorum is lost.
+## ref: https://kubernetes.io/docs/tutorials/stateful-application/zookeeper/
+podManagementPolicy: Parallel
 
 ## The StatefulSet Update Strategy which Zookeeper will use when changes are applied: OnDelete or RollingUpdate
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
@@ -53,6 +55,13 @@ heapOptions: "-Xms512M -Xmx512M"
 serverPort: 2888
 leaderElectionPort: 3888
 clientPort: 2181
+
+## Health checks properties.
+## Only required, if podManagementPolicy is 'Parallel'
+clientReadiness:
+  initialDelaySeconds: 10
+clientLiveness:
+  initialDelaySeconds: 50
 
 ## Persistent Volumes
 ## ref: https://kubernetes.io/docs/concepts/storage/persistent-volumes/


### PR DESCRIPTION
## What changes were proposed in this pull request?
* Add healthchecks for zookeeper statefulset (client-only)
* Adjust podManagementPolicy to Parallel in order to maintain zookeeper quorum

## How was this patch tested?
* Helm install and Helm upgrade on EKS
