### PR TITLE
An option to add a custom topic prefix is added and if not defined wi…

### DIFF
--- a/charts/cp-kafka-connect/templates/_helpers.tpl
+++ b/charts/cp-kafka-connect/templates/_helpers.tpl
@@ -25,6 +25,19 @@ If release name contains chart name it will be used as a full name.
 {{- end -}}
 
 {{/*
+Create a default prefix for the topics (config, offsets and status).
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If an override not supplied, we'll use cp-kafka-connect.fullname.
+*/}}
+{{- define "cp-kafka-connect.topics-prefix" -}}
+{{- if .Values.topicsPrefix -}}
+{{- .Values.topicsPrefix | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- (include "cp-kafka-connect.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
 Create chart name and version as used by the chart label.
 */}}
 {{- define "cp-kafka-connect.chart" -}}

--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -74,11 +74,11 @@ spec:
             - name: CONNECT_GROUP_ID
               value: {{ template "cp-kafka-connect.groupId" . }}
             - name: CONNECT_CONFIG_STORAGE_TOPIC
-              value: {{ template "cp-kafka-connect.fullname" . }}-config
+              value: {{ template "cp-kafka-connect.topics-prefix" . }}-config
             - name: CONNECT_OFFSET_STORAGE_TOPIC
-              value: {{ template "cp-kafka-connect.fullname" . }}-offset
+              value: {{ template "cp-kafka-connect.topics-prefix" . }}-offset
             - name: CONNECT_STATUS_STORAGE_TOPIC
-              value: {{ template "cp-kafka-connect.fullname" . }}-status
+              value: {{ template "cp-kafka-connect.topics-prefix" . }}-status
             - name: CONNECT_KEY_CONVERTER_SCHEMA_REGISTRY_URL
               value: {{ template "cp-kafka-connect.cp-schema-registry.service-name" .}}
             - name: CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL


### PR DESCRIPTION
…ll use the fullname

## What changes were proposed in this pull request?
We have a strict policy on topic names (Since we use Confluent Kafka and giving permissions according to a topic prefix).
The topics name we have contain "." which is not allowed in Service names.
Since fullNameOverride used both for topics' prefix and for the services names (ConfigMap, Service, Deployment, etc), we can't enforce the naming policy.

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. helm upgrade on minikube, helm install on gke)
Helm install on K8s cluster