### PR TITLE
Support overriding fullname of cp-zookeeper

### DIFF
--- a/charts/cp-kafka/templates/_helpers.tpl
+++ b/charts/cp-kafka/templates/_helpers.tpl
@@ -36,8 +36,12 @@ Create a default fully qualified zookeeper name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "cp-kafka.cp-zookeeper.fullname" -}}
+{{- if (index .Values "cp-zookeeper" "fullnameOverride") -}}
+{{- (index .Values "cp-zookeeper" "fullnameOverride") | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
 {{- $name := default "cp-zookeeper" (index .Values "cp-zookeeper" "nameOverride") -}}
 {{- printf "%s-%s-headless" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds support for overriding the fullname of `cp-zookeeper` with `.Values.cp-zookeeper.fullnameOverride`, just like what is already possible with `cp-kafka` using `.Values.fullnameOverride`.

## How was this patch tested?

On a project running in AWS EKS v1.11.8 using these values:

![image](https://user-images.githubusercontent.com/4631744/54759783-11d5c500-4bef-11e9-9c41-af6ee95c5b56.png)

And in the `StatefulSet` for `cp-kafka` we can now see:

![image](https://user-images.githubusercontent.com/4631744/54755345-121d9280-4be6-11e9-9338-8dd5c7a79673.png)
