### PR TITLE
Expose the jmx port in service, when jmx is enabled.

### DIFF
--- a/charts/cp-kafka-connect/templates/service.yaml
+++ b/charts/cp-kafka-connect/templates/service.yaml
@@ -11,6 +11,10 @@ spec:
   ports:
     - name: kafka-connect
       port: {{ .Values.servicePort }}
+    {{- if .Values.prometheus.jmx.enabled }}
+    - name: metrics
+      port: {{ .Values.prometheus.jmx.port }}
+    {{- end }}
   selector:
     app: {{ template "cp-kafka-connect.name" . }}
     release: {{ .Release.Name }}

--- a/charts/cp-kafka-rest/templates/service.yaml
+++ b/charts/cp-kafka-rest/templates/service.yaml
@@ -11,6 +11,10 @@ spec:
   ports:
     - name: rest-proxy
       port: {{ .Values.servicePort }}
+    {{- if .Values.prometheus.jmx.enabled }}
+    - name: metrics
+      port: {{ .Values.prometheus.jmx.port }}
+    {{- end }}
   selector:
     app: {{ template "cp-kafka-rest.name" . }}
     release: {{ .Release.Name }}

--- a/charts/cp-kafka/templates/service.yaml
+++ b/charts/cp-kafka/templates/service.yaml
@@ -11,6 +11,10 @@ spec:
   ports:
     - port: 9092
       name: broker
+    {{- if .Values.prometheus.jmx.enabled }}
+    - port: {{ .Values.prometheus.jmx.port }}
+      name: metrics
+    {{- end }}
   selector:
     app: {{ template "cp-kafka.name" . }}
     release: {{ .Release.Name }}

--- a/charts/cp-ksql-server/templates/service.yaml
+++ b/charts/cp-ksql-server/templates/service.yaml
@@ -11,6 +11,10 @@ spec:
   ports:
       - name: ksql-server
         port: {{ .Values.servicePort }}
+    {{- if .Values.prometheus.jmx.enabled }}
+      - name: metrics
+        port: {{ .Values.prometheus.jmx.port }}
+    {{- end }}
   selector:
     app: {{ template "cp-ksql-server.name" . }}
     release: {{ .Release.Name }}

--- a/charts/cp-schema-registry/templates/service.yaml
+++ b/charts/cp-schema-registry/templates/service.yaml
@@ -11,6 +11,10 @@ spec:
   ports:
     - name: schema-registry
       port: {{ .Values.servicePort }}
+    {{- if .Values.prometheus.jmx.enabled }}
+    - name: metrics
+      port: {{ .Values.prometheus.jmx.port }}
+    {{- end }}
   selector:
     app: {{ template "cp-schema-registry.name" . }}
     release: {{ .Release.Name }}

--- a/charts/cp-zookeeper/templates/service.yaml
+++ b/charts/cp-zookeeper/templates/service.yaml
@@ -12,6 +12,10 @@ spec:
   ports:
     - port: {{ .Values.clientPort }}
       name: client
+    {{- if .Values.prometheus.jmx.enabled }}
+    - name: metrics
+      port: {{ .Values.prometheus.jmx.port }}
+    {{- end }}
   selector:
     app: {{ template "cp-zookeeper.name" . }}
     release: {{ .Release.Name }}


### PR DESCRIPTION
# What changes were proposed in this pull request?
Closes #241 The jmx port is not exposed and thus makes it impossible to monitor using prometheus-operator and service monitors. 
If jmx is enabled for the chart, the service should also expose the jmx port.

## How was this patch tested?
Forked the repo, created a chart with the changes and deployed with helm.
