### PR TITLE
Allow disabling grandchild components from grandparent chart

### DIFF
--- a/requirements.yaml
+++ b/requirements.yaml
@@ -2,24 +2,24 @@ dependencies:
 - name: cp-kafka
   version: 0.1.0
   repository: file://./charts/cp-kafka
-  condition: cp-kafka.enabled
+  condition: cp-helm-charts.cp-kafka.enabled,cp-kafka.enabled
 - name: cp-zookeeper
   version: 0.1.0
   repository: file://./charts/cp-zookeeper
-  condition: cp-zookeeper.enabled
+  condition: cp-helm-charts.cp-zookeeper.enabled,cp-zookeeper.enabled
 - name: cp-schema-registry
   version: 0.1.0
   repository: file://./charts/cp-schema-registry
-  condition: cp-schema-registry.enabled
+  condition: cp-helm-charts.cp-schema-registry.enabled,cp-schema-registry.enabled
 - name: cp-kafka-rest
   version: 0.1.0
   repository: file://./charts/cp-kafka-rest
-  condition: cp-kafka-rest.enabled
+  condition: cp-helm-charts.cp-kafka-rest.enabled,cp-kafka-rest.enabled
 - name: cp-kafka-connect
   version: 0.1.0
   repository: file://./charts/cp-kafka-connect
-  condition: cp-kafka-connect.enabled
+  condition: cp-helm-charts.cp-kafka-connect.enabled,cp-kafka-connect.enabled
 - name: cp-ksql-server
   version: 0.1.0
   repository: file://./charts/cp-ksql-server
-  condition: cp-ksql-server.enabled
+  condition: cp-helm-charts.cp-ksql-server.enabled,cp-ksql-server.enabled


### PR DESCRIPTION
This PR allows a grandparent chart (a chart that has `cp-helm-charts` as a dependency in requirements.yaml) to disable specific components, e.g. `cp-kafka-connect`, from the same root key (`cp-helm-charts`).

Because of this: https://github.com/helm/helm/issues/4490#issuecomment-415911053

You would otherwise have to do something like:

![image](https://user-images.githubusercontent.com/4631744/54757374-5ca10e00-4bea-11e9-8f92-f51c96809c41.png)

Where certain stuff has to be below the key `cp-helm-charts` while the requirement conditions are evaluated from root.

But as per the comment above, "first matched condition wins", so one can support both scenarios with the changes in this PR. I can now _also_ do:

![image](https://user-images.githubusercontent.com/4631744/54757397-6dea1a80-4bea-11e9-97dd-081a74153f69.png)

## How was this patch tested?

On a project running in AWS EKS v1.11.8.
