### PR TITLE
Use cp-kafka.fullname for Kafka broker nodeport-service name

### DIFF
--- a/charts/cp-kafka/templates/nodeport-service.yaml
+++ b/charts/cp-kafka/templates/nodeport-service.yaml
@@ -10,7 +10,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ $root.Release.Name }}-{{ $i }}-nodeport
+  name: {{ template "cp-kafka.fullname" $root }}-{{ $i }}-nodeport
   labels:
     app: {{ include "cp-kafka.name" $root }}
     chart: {{ template "cp-kafka.chart" $root }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Use the `cp-kafka.fullname` helper to construct the name of the nodeport-service of individual Brokers.

This way, the names will more closely match the other services created by the `cp-kafka` chart:

![image](https://user-images.githubusercontent.com/4631744/55038718-156bb080-5022-11e9-8f6c-fd6ee21154af.png)

## How was this patch tested?

Forked chart, running on a project running in AWS EKS v1.11.8.