### PR TITLE
Servicemonitor

### DIFF
--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -18,12 +18,12 @@ spec:
       labels:
         app: {{ template "cp-kafka-connect.name" . }}
         release: {{ .Release.Name }}
-      {{- if or .Values.podAnnotations .Values.prometheus.jmx.enabled }}
+      {{- if or .Values.podAnnotations (and .Values.prometheus.jmx.enabled (not .Values.prometheus.jmx.serviceMonitor.enabled)) }}
       annotations:
       {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}
-      {{- if .Values.prometheus.jmx.enabled }}
+      {{- if and .Values.prometheus.jmx.enabled (not .Values.prometheus.jmx.serviceMonitor.enabled) }}
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ .Values.prometheus.jmx.port | quote }}
       {{- end }}

--- a/charts/cp-kafka-connect/templates/metrics-service.yaml
+++ b/charts/cp-kafka-connect/templates/metrics-service.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.prometheus.jmx.enabled .Values.prometheus.jmx.serviceMonitor }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "cp-kafka-connect.fullname" . }}-metrics
+  labels:
+    app: {{ template "cp-kafka-connect.name" . }}
+    chart: {{ template "cp-kafka-connect.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: metrics
+spec:
+  ports:
+    - port: {{ .Values.prometheus.jmx.port }}
+      name: metrics
+  selector:
+    app: {{ template "cp-kafka-connect.name" . }}
+    release: {{ .Release.Name }}
+{{- end }}

--- a/charts/cp-kafka-connect/templates/servicemonitor.yaml
+++ b/charts/cp-kafka-connect/templates/servicemonitor.yaml
@@ -23,4 +23,6 @@ spec:
   endpoints:
     - port: metrics
       interval: {{ .Values.prometheus.jmx.serviceMonitor.interval }}
+  targetLabels:
+    - release
 {{- end }}

--- a/charts/cp-kafka-connect/templates/servicemonitor.yaml
+++ b/charts/cp-kafka-connect/templates/servicemonitor.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.prometheus.jmx.enabled .Values.prometheus.jmx.serviceMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "cp-kafka-connect.fullname" . }}
+  namespace: {{ .Values.prometheus.jmx.serviceMonitor.namespace }}
+  labels:
+    app: {{ template "cp-kafka-connect.name" . }}
+    chart: {{ template "cp-kafka-connect.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  jobLabel: {{ template "cp-kafka-connect.fullname" . }}
+  selector:
+    matchLabels:
+      app: {{ template "cp-kafka-connect.name" . }}
+      release: {{ .Release.Name }}
+      component: metrics
+  namespaceSelector:
+    matchNames:
+      - {{ $.Release.Namespace }}
+  endpoints:
+    - port: metrics
+      interval: {{ .Values.prometheus.jmx.serviceMonitor.interval }}
+{{- end }}

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -80,6 +80,12 @@ prometheus:
     imageTag: 6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143
     port: 5556
 
+    ## Service monitor
+    serviceMonitor:
+      enabled: false
+      namespace: kube-system
+      interval: 30s
+
     ## Resources configuration for the JMX exporter container.
     ## See the `resources` documentation above for details.
     resources: {}

--- a/charts/cp-kafka-rest/templates/deployment.yaml
+++ b/charts/cp-kafka-rest/templates/deployment.yaml
@@ -18,12 +18,12 @@ spec:
       labels:
         app: {{ template "cp-kafka-rest.name" . }}
         release: {{ .Release.Name }}
-      {{- if or .Values.podAnnotations .Values.prometheus.jmx.enabled }}
+      {{- if or .Values.podAnnotations (and .Values.prometheus.jmx.enabled (not .Values.prometheus.jmx.serviceMonitor.enabled)) }}
       annotations:
       {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}
-      {{- if .Values.prometheus.jmx.enabled }}
+      {{- if and .Values.prometheus.jmx.enabled (not .Values.prometheus.jmx.serviceMonitor.enabled) }}
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ .Values.prometheus.jmx.port | quote }}
       {{- end }}

--- a/charts/cp-kafka-rest/templates/metrics-service.yaml
+++ b/charts/cp-kafka-rest/templates/metrics-service.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.prometheus.jmx.enabled .Values.prometheus.jmx.serviceMonitor }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "cp-kafka-rest.fullname" . }}-metrics
+  labels:
+    app: {{ template "cp-kafka-rest.name" . }}
+    chart: {{ template "cp-kafka-rest.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: metrics
+spec:
+  ports:
+    - port: {{ .Values.prometheus.jmx.port }}
+      name: metrics
+  selector:
+    app: {{ template "cp-kafka-rest.name" . }}
+    release: {{ .Release.Name }}
+{{- end }}

--- a/charts/cp-kafka-rest/templates/servicemonitor.yaml
+++ b/charts/cp-kafka-rest/templates/servicemonitor.yaml
@@ -23,4 +23,6 @@ spec:
   endpoints:
     - port: metrics
       interval: {{ .Values.prometheus.jmx.serviceMonitor.interval }}
+  targetLabels:
+    - release
 {{- end }}

--- a/charts/cp-kafka-rest/templates/servicemonitor.yaml
+++ b/charts/cp-kafka-rest/templates/servicemonitor.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.prometheus.jmx.enabled .Values.prometheus.jmx.serviceMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "cp-kafka-rest.fullname" . }}
+  namespace: {{ .Values.prometheus.jmx.serviceMonitor.namespace }}
+  labels:
+    app: {{ template "cp-kafka-rest.name" . }}
+    chart: {{ template "cp-kafka-rest.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  jobLabel: {{ template "cp-kafka-rest.fullname" . }}
+  selector:
+    matchLabels:
+      app: {{ template "cp-kafka-rest.name" . }}
+      release: {{ .Release.Name }}
+      component: metrics
+  namespaceSelector:
+    matchNames:
+      - {{ $.Release.Namespace }}
+  endpoints:
+    - port: metrics
+      interval: {{ .Values.prometheus.jmx.serviceMonitor.interval }}
+{{- end }}

--- a/charts/cp-kafka-rest/values.yaml
+++ b/charts/cp-kafka-rest/values.yaml
@@ -68,6 +68,12 @@ prometheus:
     imageTag: 6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143
     port: 5556
 
+    ## Service monitor
+    serviceMonitor:
+      enabled: false
+      namespace: kube-system
+      interval: 30s
+
     ## Resources configuration for the JMX exporter container.
     ## See the `resources` documentation above for details.
     resources: {}

--- a/charts/cp-kafka/templates/metrics-service.yaml
+++ b/charts/cp-kafka/templates/metrics-service.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.prometheus.jmx.enabled .Values.prometheus.jmx.serviceMonitor }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "cp-kafka.fullname" . }}-metrics
+  labels:
+    app: {{ template "cp-kafka.name" . }}
+    chart: {{ template "cp-kafka.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: metrics
+spec:
+  ports:
+    - port: {{ .Values.prometheus.jmx.port }}
+      name: metrics
+  selector:
+    app: {{ template "cp-kafka.name" . }}
+    release: {{ .Release.Name }}
+{{- end }}

--- a/charts/cp-kafka/templates/servicemonitor.yaml
+++ b/charts/cp-kafka/templates/servicemonitor.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.prometheus.jmx.enabled .Values.prometheus.jmx.serviceMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "cp-kafka.fullname" . }}
+  namespace: {{ .Values.prometheus.jmx.serviceMonitor.namespace }}
+  labels:
+    app: {{ template "cp-kafka.name" . }}
+    chart: {{ template "cp-kafka.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  jobLabel: {{ template "cp-kafka.fullname" . }}
+  selector:
+    matchLabels:
+      app: {{ template "cp-kafka.name" . }}
+      release: {{ .Release.Name }}
+      component: metrics
+  namespaceSelector:
+    matchNames:
+      - {{ $.Release.Namespace }}
+  endpoints:
+    - port: metrics
+      interval: {{ .Values.prometheus.jmx.serviceMonitor.interval }}
+{{- end }}

--- a/charts/cp-kafka/templates/servicemonitor.yaml
+++ b/charts/cp-kafka/templates/servicemonitor.yaml
@@ -23,4 +23,6 @@ spec:
   endpoints:
     - port: metrics
       interval: {{ .Values.prometheus.jmx.serviceMonitor.interval }}
+  targetLabels:
+    - release
 {{- end }}

--- a/charts/cp-kafka/templates/statefulset.yaml
+++ b/charts/cp-kafka/templates/statefulset.yaml
@@ -18,12 +18,12 @@ spec:
       labels:
         app: {{ template "cp-kafka.name" . }}
         release: {{ .Release.Name }}
-      {{- if or .Values.podAnnotations .Values.prometheus.jmx.enabled }}
+      {{- if or .Values.podAnnotations (and .Values.prometheus.jmx.enabled (not .Values.prometheus.jmx.serviceMonitor.enabled)) }}
       annotations:
       {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}
-      {{- if .Values.prometheus.jmx.enabled }}
+      {{- if and .Values.prometheus.jmx.enabled (not .Values.prometheus.jmx.serviceMonitor.enabled) }}
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ .Values.prometheus.jmx.port | quote }}
       {{- end }}

--- a/charts/cp-kafka/values.yaml
+++ b/charts/cp-kafka/values.yaml
@@ -116,6 +116,12 @@ prometheus:
     imageTag: 6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143
     port: 5556
 
+    ## Service monitor
+    serviceMonitor:
+      enabled: false
+      namespace: kube-system
+      interval: 30s
+
     ## Resources configuration for the JMX exporter container.
     ## See the `resources` documentation above for details.
     resources: {}

--- a/charts/cp-ksql-server/templates/deployment.yaml
+++ b/charts/cp-ksql-server/templates/deployment.yaml
@@ -18,12 +18,12 @@ spec:
       labels:
         app: {{ template "cp-ksql-server.name" . }}
         release: {{ .Release.Name }}
-      {{- if or .Values.podAnnotations .Values.prometheus.jmx.enabled }}
+      {{- if or .Values.podAnnotations (and .Values.prometheus.jmx.enabled (not .Values.prometheus.jmx.serviceMonitor.enabled)) }}
       annotations:
       {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}
-      {{- if .Values.prometheus.jmx.enabled }}
+      {{- if and .Values.prometheus.jmx.enabled (not .Values.prometheus.jmx.serviceMonitor.enabled) }}
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ .Values.prometheus.jmx.port | quote }}
       {{- end }}

--- a/charts/cp-ksql-server/templates/metrics-service.yaml
+++ b/charts/cp-ksql-server/templates/metrics-service.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.prometheus.jmx.enabled .Values.prometheus.jmx.serviceMonitor }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "cp-ksql-server.fullname" . }}-metrics
+  labels:
+    app: {{ template "cp-ksql-server.name" . }}
+    chart: {{ template "cp-ksql-server.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: metrics
+spec:
+  ports:
+    - port: {{ .Values.prometheus.jmx.port }}
+      name: metrics
+  selector:
+    app: {{ template "cp-ksql-server.name" . }}
+    release: {{ .Release.Name }}
+{{- end }}

--- a/charts/cp-ksql-server/templates/servicemonitor.yaml
+++ b/charts/cp-ksql-server/templates/servicemonitor.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.prometheus.jmx.enabled .Values.prometheus.jmx.serviceMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "cp-ksql-server.fullname" . }}
+  namespace: {{ .Values.prometheus.jmx.serviceMonitor.namespace }}
+  labels:
+    app: {{ template "cp-ksql-server.name" . }}
+    chart: {{ template "cp-ksql-server.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  jobLabel: {{ template "cp-ksql-server.fullname" . }}
+  selector:
+    matchLabels:
+      app: {{ template "cp-ksql-server.name" . }}
+      release: {{ .Release.Name }}
+      component: metrics
+  namespaceSelector:
+    matchNames:
+      - {{ $.Release.Namespace }}
+  endpoints:
+    - port: metrics
+      interval: {{ .Values.prometheus.jmx.serviceMonitor.interval }}
+{{- end }}

--- a/charts/cp-ksql-server/templates/servicemonitor.yaml
+++ b/charts/cp-ksql-server/templates/servicemonitor.yaml
@@ -23,4 +23,6 @@ spec:
   endpoints:
     - port: metrics
       interval: {{ .Values.prometheus.jmx.serviceMonitor.interval }}
+  targetLabels:
+    - release
 {{- end }}

--- a/charts/cp-ksql-server/values.yaml
+++ b/charts/cp-ksql-server/values.yaml
@@ -63,6 +63,12 @@ prometheus:
     imageTag: 6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143
     port: 5556
 
+    ## Service monitor
+    serviceMonitor:
+      enabled: false
+      namespace: kube-system
+      interval: 30s
+
     ## Resources configuration for the JMX exporter container.
     ## See the `resources` documentation above for details.
     resources: {}

--- a/charts/cp-schema-registry/templates/deployment.yaml
+++ b/charts/cp-schema-registry/templates/deployment.yaml
@@ -18,12 +18,12 @@ spec:
       labels:
         app: {{ template "cp-schema-registry.name" . }}
         release: {{ .Release.Name }}
-      {{- if or .Values.podAnnotations .Values.prometheus.jmx.enabled }}
+      {{- if or .Values.podAnnotations (and .Values.prometheus.jmx.enabled (not .Values.prometheus.jmx.serviceMonitor.enabled)) }}
       annotations:
       {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}
-      {{- if .Values.prometheus.jmx.enabled }}
+      {{- if and .Values.prometheus.jmx.enabled (not .Values.prometheus.jmx.serviceMonitor.enabled) }}
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ .Values.prometheus.jmx.port | quote }}
       {{- end }}

--- a/charts/cp-schema-registry/templates/metrics-service.yaml
+++ b/charts/cp-schema-registry/templates/metrics-service.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.prometheus.jmx.enabled .Values.prometheus.jmx.serviceMonitor }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "cp-schema-registry.fullname" . }}-metrics
+  labels:
+    app: {{ template "cp-schema-registry.name" . }}
+    chart: {{ template "cp-schema-registry.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: metrics
+spec:
+  ports:
+    - port: {{ .Values.prometheus.jmx.port }}
+      name: metrics
+  selector:
+    app: {{ template "cp-schema-registry.name" . }}
+    release: {{ .Release.Name }}
+{{- end }}

--- a/charts/cp-schema-registry/templates/servicemonitor.yaml
+++ b/charts/cp-schema-registry/templates/servicemonitor.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.prometheus.jmx.enabled .Values.prometheus.jmx.serviceMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "cp-schema-registry.fullname" . }}
+  namespace: {{ .Values.prometheus.jmx.serviceMonitor.namespace }}
+  labels:
+    app: {{ template "cp-schema-registry.name" . }}
+    chart: {{ template "cp-schema-registry.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  jobLabel: {{ template "cp-schema-registry.fullname" . }}
+  selector:
+    matchLabels:
+      app: {{ template "cp-schema-registry.name" . }}
+      release: {{ .Release.Name }}
+      component: metrics
+  namespaceSelector:
+    matchNames:
+      - {{ $.Release.Namespace }}
+  endpoints:
+    - port: metrics
+      interval: {{ .Values.prometheus.jmx.serviceMonitor.interval }}
+{{- end }}

--- a/charts/cp-schema-registry/templates/servicemonitor.yaml
+++ b/charts/cp-schema-registry/templates/servicemonitor.yaml
@@ -23,4 +23,6 @@ spec:
   endpoints:
     - port: metrics
       interval: {{ .Values.prometheus.jmx.serviceMonitor.interval }}
+  targetLabels:
+    - release
 {{- end }}

--- a/charts/cp-schema-registry/values.yaml
+++ b/charts/cp-schema-registry/values.yaml
@@ -82,4 +82,10 @@ prometheus:
     imageTag: 6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143
     port: 5556
 
+    ## Service monitor
+    serviceMonitor:
+      enabled: false
+      namespace: kube-system
+      interval: 30s
+
     resources: {}

--- a/charts/cp-zookeeper/templates/metrics-service.yaml
+++ b/charts/cp-zookeeper/templates/metrics-service.yaml
@@ -1,0 +1,20 @@
+{{- if and .Values.prometheus.jmx.enabled .Values.prometheus.jmx.serviceMonitor }}
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "cp-zookeeper.fullname" . }}-metrics
+  labels:
+    app: {{ template "cp-zookeeper.name" . }}
+    chart: {{ template "cp-zookeeper.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+    component: metrics
+spec:
+  ports:
+    - port: {{ .Values.prometheus.jmx.port }}
+      name: metrics
+  selector:
+    app: {{ template "cp-zookeeper.name" . }}
+    release: {{ .Release.Name }}
+{{- end }}

--- a/charts/cp-zookeeper/templates/servicemonitor.yaml
+++ b/charts/cp-zookeeper/templates/servicemonitor.yaml
@@ -1,0 +1,26 @@
+{{- if and .Values.prometheus.jmx.enabled .Values.prometheus.jmx.serviceMonitor.enabled }}
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "cp-zookeeper.fullname" . }}
+  namespace: {{ .Values.prometheus.jmx.serviceMonitor.namespace }}
+  labels:
+    app: {{ template "cp-zookeeper.name" . }}
+    chart: {{ template "cp-zookeeper.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  jobLabel: {{ template "cp-zookeeper.fullname" . }}
+  selector:
+    matchLabels:
+      app: {{ template "cp-zookeeper.name" . }}
+      release: {{ .Release.Name }}
+      component: metrics
+  namespaceSelector:
+    matchNames:
+      - {{ $.Release.Namespace }}
+  endpoints:
+    - port: metrics
+      interval: {{ .Values.prometheus.jmx.serviceMonitor.interval }}
+{{- end }}

--- a/charts/cp-zookeeper/templates/servicemonitor.yaml
+++ b/charts/cp-zookeeper/templates/servicemonitor.yaml
@@ -23,4 +23,6 @@ spec:
   endpoints:
     - port: metrics
       interval: {{ .Values.prometheus.jmx.serviceMonitor.interval }}
+  targetLabels:
+    - release
 {{- end }}

--- a/charts/cp-zookeeper/templates/statefulset.yaml
+++ b/charts/cp-zookeeper/templates/statefulset.yaml
@@ -18,12 +18,12 @@ spec:
       labels:
         app: {{ template "cp-zookeeper.name" . }}
         release: {{ .Release.Name }}
-      {{- if or .Values.podAnnotations .Values.prometheus.jmx.enabled }}
+      {{- if or .Values.podAnnotations (and .Values.prometheus.jmx.enabled (not .Values.prometheus.jmx.serviceMonitor.enabled)) }}
       annotations:
       {{- range $key, $value := .Values.podAnnotations }}
         {{ $key }}: {{ $value | quote }}
       {{- end }}
-      {{- if .Values.prometheus.jmx.enabled }}
+      {{- if and .Values.prometheus.jmx.enabled (not .Values.prometheus.jmx.serviceMonitor.enabled) }}
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ .Values.prometheus.jmx.port | quote }}
       {{- end }}

--- a/charts/cp-zookeeper/values.yaml
+++ b/charts/cp-zookeeper/values.yaml
@@ -113,6 +113,12 @@ prometheus:
     imageTag: 6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143
     port: 5556
 
+    ## Service monitor
+    serviceMonitor:
+      enabled: false
+      namespace: kube-system
+      interval: 30s
+
     ## Resources configuration for the JMX exporter container.
     ## See the `resources` documentation above for details.
     resources: {}


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add `ServiceMonitor` configuration in order to be used by [Prometheus operator](https://github.com/coreos/prometheus-operator).

## How was this patch tested?
`helm install` on EKS (running on our production environment). After deploying, metrics are present on our Prometheus.