### PR TITLE
add control-center charts

### DIFF
--- a/charts/cp-control-center/.helmignore
+++ b/charts/cp-control-center/.helmignore
@@ -1,0 +1,21 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj

--- a/charts/cp-control-center/Chart.yaml
+++ b/charts/cp-control-center/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+appVersion: "1.0"
+description: A Helm chart Confluent Control Center for Kubernetes
+name: cp-control-center
+version: 0.1.0

--- a/charts/cp-control-center/templates/NOTES.txt
+++ b/charts/cp-control-center/templates/NOTES.txt
@@ -1,0 +1,9 @@
+This chart installs a Confluent Control Center
+
+To connect to Confluent Control Center directly from outside the k8s cluster:
+
+1. Execute the following command to setup port forward from k8s to localhost 
+	export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "cp-enterprise-control-center.name" . }}" -o jsonpath="{.items[0].metadata.name}")
+ 	kubectl port-forward $POD_NAME {{ .Values.serviceHttpPort }}
+
+2. Open a browser and visit http://localhost:{{ .Values.serviceHttpPort }}

--- a/charts/cp-control-center/templates/NOTES.txt
+++ b/charts/cp-control-center/templates/NOTES.txt
@@ -3,7 +3,7 @@ This chart installs a Confluent Control Center
 To connect to Confluent Control Center directly from outside the k8s cluster:
 
 1. Execute the following command to setup port forward from k8s to localhost 
-	export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "cp-enterprise-control-center.name" . }}" -o jsonpath="{.items[0].metadata.name}")
+	export POD_NAME=$(kubectl get pods --namespace {{ .Release.Namespace }} -l "app={{ template "cp-control-center.name" . }}" -o jsonpath="{.items[0].metadata.name}")
  	kubectl port-forward $POD_NAME {{ .Values.serviceHttpPort }}
 
 2. Open a browser and visit http://localhost:{{ .Values.serviceHttpPort }}

--- a/charts/cp-control-center/templates/_helpers.tpl
+++ b/charts/cp-control-center/templates/_helpers.tpl
@@ -2,7 +2,7 @@
 {{/*
 Expand the name of the chart.
 */}}
-{{- define "cp-enterprise-control-center.name" -}}
+{{- define "cp-control-center.name" -}}
 {{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -11,7 +11,7 @@ Create a default fully qualified app name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 If release name contains chart name it will be used as a full name.
 */}}
-{{- define "cp-enterprise-control-center.fullname" -}}
+{{- define "cp-control-center.fullname" -}}
 {{- if .Values.fullnameOverride -}}
 {{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
 {{- else -}}
@@ -27,7 +27,7 @@ If release name contains chart name it will be used as a full name.
 {{/*
 Create chart name and version as used by the chart label.
 */}}
-{{- define "cp-enterprise-control-center.chart" -}}
+{{- define "cp-control-center.chart" -}}
 {{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
@@ -35,7 +35,7 @@ Create chart name and version as used by the chart label.
 Create a default fully qualified kafka headless name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "cp-enterprise-control-center.cp-kafka-headless.fullname" -}}
+{{- define "cp-control-center.cp-kafka-headless.fullname" -}}
 {{- $name := "cp-kafka-headless" -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
@@ -44,11 +44,11 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Form the Kafka URL. If Kafka is installed as part of this chart, use k8s service discovery,
 else use user-provided URL
 */}}
-{{- define "cp-enterprise-control-center.kafka.bootstrapServers" -}}
+{{- define "cp-control-center.kafka.bootstrapServers" -}}
 {{- if .Values.kafka.bootstrapServers -}}
 {{- .Values.kafka.bootstrapServers -}}
 {{- else -}}
-{{- printf "PLAINTEXT://%s:9092" (include "cp-enterprise-control-center.cp-kafka-headless.fullname" .) -}}
+{{- printf "PLAINTEXT://%s:9092" (include "cp-control-center.cp-kafka-headless.fullname" .) -}}
 {{- end -}}
 {{- end -}}
 
@@ -56,16 +56,16 @@ else use user-provided URL
 Create a default fully qualified schema registry name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "cp-enterprise-control-center.cp-schema-registry.fullname" -}}
+{{- define "cp-control-center.cp-schema-registry.fullname" -}}
 {{- $name := default "cp-schema-registry" (index .Values "cp-schema-registry" "nameOverride") -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{- define "cp-enterprise-control-center.cp-schema-registry.service-name" -}}
+{{- define "cp-control-center.cp-schema-registry.service-name" -}}
 {{- if (index .Values "cp-schema-registry" "url") -}}
 {{- printf "%s" (index .Values "cp-schema-registry" "url") -}}
 {{- else -}}
-{{- printf "http://%s:8081" (include "cp-enterprise-control-center.cp-schema-registry.fullname" .) -}}
+{{- printf "http://%s:8081" (include "cp-control-center.cp-schema-registry.fullname" .) -}}
 {{- end -}}
 {{- end -}}
 
@@ -73,16 +73,16 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Create a default fully qualified connect name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "cp-enterprise-control-center.cp-kafka-connect.fullname" -}}
+{{- define "cp-control-center.cp-kafka-connect.fullname" -}}
 {{- $name := default "cp-kafka-connect" (index .Values "cp-kafka-connect" "nameOverride") -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{- define "cp-enterprise-control-center.cp-kafka-connect.service-name" -}}
+{{- define "cp-control-center.cp-kafka-connect.service-name" -}}
 {{- if (index .Values "cp-kafka-connect" "url") -}}
 {{- printf "%s" (index .Values "cp-kafka-connect" "url") -}}
 {{- else -}}
-{{- printf "http://%s:8083" (include "cp-enterprise-control-center.cp-kafka-connect.fullname" .) -}}
+{{- printf "http://%s:8083" (include "cp-control-center.cp-kafka-connect.fullname" .) -}}
 {{- end -}}
 {{- end -}}
 
@@ -90,16 +90,16 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Create a default fully qualified ksql name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "cp-enterprise-control-center.cp-ksql-server.fullname" -}}
+{{- define "cp-control-center.cp-ksql-server.fullname" -}}
 {{- $name := default "cp-ksql-server" (index .Values "cp-ksql-server" "nameOverride") -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
-{{- define "cp-enterprise-control-center.cp-ksql-server.service-name" -}}
+{{- define "cp-control-center.cp-ksql-server.service-name" -}}
 {{- if (index .Values "cp-ksql-server" "url") -}}
 {{- printf "%s" (index .Values "cp-ksql-server" "url") -}}
 {{- else -}}
-{{- printf "http://%s:8088" (include "cp-enterprise-control-center.cp-ksql-server.fullname" .) -}}
+{{- printf "http://%s:8088" (include "cp-control-center.cp-ksql-server.fullname" .) -}}
 {{- end -}}
 {{- end -}}
 
@@ -107,7 +107,7 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Create a default fully qualified zookeeper name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
-{{- define "cp-enterprise-control-center.cp-zookeeper.fullname" -}}
+{{- define "cp-control-center.cp-zookeeper.fullname" -}}
 {{- $name := default "cp-zookeeper" (index .Values "cp-zookeeper" "nameOverride") -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
@@ -116,10 +116,10 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 Form the Zookeeper URL. If zookeeper is installed as part of this chart, use k8s service discovery,
 else use user-provided URL
 */}}
-{{- define "cp-enterprise-control-center.cp-zookeeper.service-name" }}
+{{- define "cp-control-center.cp-zookeeper.service-name" }}
 {{- if (index .Values "cp-zookeeper" "enabled") -}}
 {{- $clientPort := default 2181 (index .Values "cp-zookeeper" "clientPort") | int -}}
-{{- printf "%s:%d" (include "cp-enterprise-control-center.cp-zookeeper.fullname" .) $clientPort }}
+{{- printf "%s:%d" (include "cp-control-center.cp-zookeeper.fullname" .) $clientPort }}
 {{- else -}}
 {{- $zookeeperConnect := printf "%s" (index .Values "cp-zookeeper" "url") }}
 {{- $zookeeperConnectOverride := (index .Values "configurationOverrides" "zookeeper.connect") }}

--- a/charts/cp-control-center/templates/_helpers.tpl
+++ b/charts/cp-control-center/templates/_helpers.tpl
@@ -1,0 +1,128 @@
+{{/* vim: set filetype=mustache: */}}
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "cp-enterprise-control-center.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "cp-enterprise-control-center.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "cp-enterprise-control-center.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified kafka headless name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "cp-enterprise-control-center.cp-kafka-headless.fullname" -}}
+{{- $name := "cp-kafka-headless" -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Form the Kafka URL. If Kafka is installed as part of this chart, use k8s service discovery,
+else use user-provided URL
+*/}}
+{{- define "cp-enterprise-control-center.kafka.bootstrapServers" -}}
+{{- if .Values.kafka.bootstrapServers -}}
+{{- .Values.kafka.bootstrapServers -}}
+{{- else -}}
+{{- printf "PLAINTEXT://%s:9092" (include "cp-enterprise-control-center.cp-kafka-headless.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified schema registry name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "cp-enterprise-control-center.cp-schema-registry.fullname" -}}
+{{- $name := default "cp-schema-registry" (index .Values "cp-schema-registry" "nameOverride") -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "cp-enterprise-control-center.cp-schema-registry.service-name" -}}
+{{- if (index .Values "cp-schema-registry" "url") -}}
+{{- printf "%s" (index .Values "cp-schema-registry" "url") -}}
+{{- else -}}
+{{- printf "http://%s:8081" (include "cp-enterprise-control-center.cp-schema-registry.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified connect name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "cp-enterprise-control-center.cp-kafka-connect.fullname" -}}
+{{- $name := default "cp-kafka-connect" (index .Values "cp-kafka-connect" "nameOverride") -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "cp-enterprise-control-center.cp-kafka-connect.service-name" -}}
+{{- if (index .Values "cp-kafka-connect" "url") -}}
+{{- printf "%s" (index .Values "cp-kafka-connect" "url") -}}
+{{- else -}}
+{{- printf "http://%s:8083" (include "cp-enterprise-control-center.cp-kafka-connect.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified ksql name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "cp-enterprise-control-center.cp-ksql-server.fullname" -}}
+{{- $name := default "cp-ksql-server" (index .Values "cp-ksql-server" "nameOverride") -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "cp-enterprise-control-center.cp-ksql-server.service-name" -}}
+{{- if (index .Values "cp-ksql-server" "url") -}}
+{{- printf "%s" (index .Values "cp-ksql-server" "url") -}}
+{{- else -}}
+{{- printf "http://%s:8088" (include "cp-enterprise-control-center.cp-ksql-server.fullname" .) -}}
+{{- end -}}
+{{- end -}}
+
+{{/*
+Create a default fully qualified zookeeper name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "cp-enterprise-control-center.cp-zookeeper.fullname" -}}
+{{- $name := default "cp-zookeeper" (index .Values "cp-zookeeper" "nameOverride") -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Form the Zookeeper URL. If zookeeper is installed as part of this chart, use k8s service discovery,
+else use user-provided URL
+*/}}
+{{- define "cp-enterprise-control-center.cp-zookeeper.service-name" }}
+{{- if (index .Values "cp-zookeeper" "enabled") -}}
+{{- $clientPort := default 2181 (index .Values "cp-zookeeper" "clientPort") | int -}}
+{{- printf "%s:%d" (include "cp-enterprise-control-center.cp-zookeeper.fullname" .) $clientPort }}
+{{- else -}}
+{{- $zookeeperConnect := printf "%s" (index .Values "cp-zookeeper" "url") }}
+{{- $zookeeperConnectOverride := (index .Values "configurationOverrides" "zookeeper.connect") }}
+{{- default $zookeeperConnect $zookeeperConnectOverride }}
+{{- end -}}
+{{- end -}}

--- a/charts/cp-control-center/templates/deployment.yaml
+++ b/charts/cp-control-center/templates/deployment.yaml
@@ -1,22 +1,22 @@
 apiVersion: apps/v1beta2
 kind: Deployment
 metadata:
-  name: {{ include "cp-enterprise-control-center.fullname" . }}
+  name: {{ include "cp-control-center.fullname" . }}
   labels:
-    app: {{ include "cp-enterprise-control-center.name" . }}
-    chart: {{ include "cp-enterprise-control-center.chart" . }}
+    app: {{ include "cp-control-center.name" . }}
+    chart: {{ include "cp-control-center.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:
-      app: {{ include "cp-enterprise-control-center.name" . }}
+      app: {{ include "cp-control-center.name" . }}
       release: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        app: {{ include "cp-enterprise-control-center.name" . }}
+        app: {{ include "cp-control-center.name" . }}
         release: {{ .Release.Name }}
       {{- if or .Values.podAnnotations .Values.prometheus.jmx.enabled }}
       annotations:
@@ -41,17 +41,17 @@ spec:
 {{- toYaml .Values.resources | indent 12 }}
           env:
             - name: CONTROL_CENTER_BOOTSTRAP_SERVERS
-              value: {{ template "cp-enterprise-control-center.kafka.bootstrapServers" . }}
+              value: {{ template "cp-control-center.kafka.bootstrapServers" . }}
             - name: CONTROL_CENTER_ZOOKEEPER_CONNECT
-              value: {{ template "cp-enterprise-control-center.cp-zookeeper.service-name" . }}
+              value: {{ template "cp-control-center.cp-zookeeper.service-name" . }}
             - name: CONTROL_CENTER_CONNECT_CLUSTER
-              value: {{ template "cp-enterprise-control-center.cp-kafka-connect.service-name" . }}
+              value: {{ template "cp-control-center.cp-kafka-connect.service-name" . }}
             - name: CONTROL_CENTER_KSQL_URL
-              value: {{ template "cp-enterprise-control-center.cp-ksql-server.service-name" . }}
+              value: {{ template "cp-control-center.cp-ksql-server.service-name" . }}
             - name: CONTROL_CENTER_KSQL_ADVERTISED_URL
-              value: {{ template "cp-enterprise-control-center.cp-ksql-server.service-name" . }}
+              value: {{ template "cp-control-center.cp-ksql-server.service-name" . }}
             - name: CONTROL_CENTER_SCHEMA_REGISTRY_URL
-              value: {{ template "cp-enterprise-control-center.cp-schema-registry.service-name" . }}
+              value: {{ template "cp-control-center.cp-schema-registry.service-name" . }}
             - name: KAFKA_HEAP_OPTS
               value: "{{ .Values.heapOptions }}"
             {{- range $key, $value := .Values.configurationOverrides }}

--- a/charts/cp-control-center/templates/deployment.yaml
+++ b/charts/cp-control-center/templates/deployment.yaml
@@ -1,0 +1,80 @@
+apiVersion: apps/v1beta2
+kind: Deployment
+metadata:
+  name: {{ include "cp-enterprise-control-center.fullname" . }}
+  labels:
+    app: {{ include "cp-enterprise-control-center.name" . }}
+    chart: {{ include "cp-enterprise-control-center.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      app: {{ include "cp-enterprise-control-center.name" . }}
+      release: {{ .Release.Name }}
+  template:
+    metadata:
+      labels:
+        app: {{ include "cp-enterprise-control-center.name" . }}
+        release: {{ .Release.Name }}
+      {{- if or .Values.podAnnotations .Values.prometheus.jmx.enabled }}
+      annotations:
+      {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- if .Values.prometheus.jmx.enabled }}
+        prometheus.io/scrape: "true"
+        prometheus.io/port: {{ .Values.prometheus.jmx.port | quote }}
+      {{- end }}
+      {{- end }}
+    spec:
+      containers:
+        - name: {{ .Chart.Name }}
+          image: "{{ .Values.image }}:{{ .Values.imageTag }}"
+          imagePullPolicy: {{ .Values.imagePullPolicy }}
+          ports:
+            - name: cc-http
+              containerPort: {{ .Values.serviceHttpPort}}
+              protocol: TCP
+          resources:
+{{- toYaml .Values.resources | indent 12 }}
+          env:
+            - name: CONTROL_CENTER_BOOTSTRAP_SERVERS
+              value: {{ template "cp-enterprise-control-center.kafka.bootstrapServers" . }}
+            - name: CONTROL_CENTER_ZOOKEEPER_CONNECT
+              value: {{ template "cp-enterprise-control-center.cp-zookeeper.service-name" . }}
+            - name: CONTROL_CENTER_CONNECT_CLUSTER
+              value: {{ template "cp-enterprise-control-center.cp-kafka-connect.service-name" . }}
+            - name: CONTROL_CENTER_KSQL_URL
+              value: {{ template "cp-enterprise-control-center.cp-ksql-server.service-name" . }}
+            - name: CONTROL_CENTER_KSQL_ADVERTISED_URL
+              value: {{ template "cp-enterprise-control-center.cp-ksql-server.service-name" . }}
+            - name: CONTROL_CENTER_SCHEMA_REGISTRY_URL
+              value: {{ template "cp-enterprise-control-center.cp-schema-registry.service-name" . }}
+            - name: KAFKA_HEAP_OPTS
+              value: "{{ .Values.heapOptions }}"
+            {{- range $key, $value := .Values.configurationOverrides }}
+            - name: {{ printf "CONTROL_CENTER_%s" $key | replace "." "_" | upper | quote }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- range $key, $value := .Values.customEnv }}
+            - name: {{ $key | quote }}
+              value: {{ $value | quote }}
+            {{- end }}            
+      {{- if .Values.imagePullSecrets }}
+      imagePullSecrets:
+{{ toYaml .Values.imagePullSecrets | indent 8 }}
+      {{- end }}
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+    {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}
+    {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+    {{- end }}

--- a/charts/cp-control-center/templates/service.yaml
+++ b/charts/cp-control-center/templates/service.yaml
@@ -1,10 +1,10 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "cp-enterprise-control-center.fullname" . }}
+  name: {{ template "cp-control-center.fullname" . }}
   labels:
-    app: {{ template "cp-enterprise-control-center.name" . }}
-    chart: {{ template "cp-enterprise-control-center.chart" . }}
+    app: {{ template "cp-control-center.name" . }}
+    chart: {{ template "cp-control-center.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
@@ -12,5 +12,5 @@ spec:
     - name: cc-http
       port: {{ .Values.serviceHttpPort }}
   selector:
-    app: {{ template "cp-enterprise-control-center.name" . }}
+    app: {{ template "cp-control-center.name" . }}
     release: {{ .Release.Name }}

--- a/charts/cp-control-center/templates/service.yaml
+++ b/charts/cp-control-center/templates/service.yaml
@@ -1,0 +1,16 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "cp-enterprise-control-center.fullname" . }}
+  labels:
+    app: {{ template "cp-enterprise-control-center.name" . }}
+    chart: {{ template "cp-enterprise-control-center.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  ports:
+    - name: cc-http
+      port: {{ .Values.serviceHttpPort }}
+  selector:
+    app: {{ template "cp-enterprise-control-center.name" . }}
+    release: {{ .Release.Name }}

--- a/charts/cp-control-center/values.yaml
+++ b/charts/cp-control-center/values.yaml
@@ -1,0 +1,103 @@
+# Default values for cp-control-center.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+replicaCount: 1
+
+## Image Info
+## ref: https://hub.docker.com/r/confluentinc/cp-kafka/
+image: confluentinc/cp-enterprise-control-center
+imageTag: 5.2.0
+
+## Specify a imagePullPolicy
+## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
+imagePullPolicy: IfNotPresent
+
+## Specify an array of imagePullSecrets.
+## Secrets must be manually created in the namespace.
+## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+imagePullSecrets:
+
+serviceHttpPort: 9021
+
+## Control Center properties
+## ref: 
+configurationOverrides:
+  "replication.factor": "3"
+  # "internal.topics.replication": "1"
+  # "monitoring.interceptor.topic.replication": "1"
+  # "metrics.topic.replication": "1"
+  # "command.topic.replication": "1"
+  # "streams.num.stream.threads": "2"
+  # "streams.consumer.request.timeout.ms": "960032"
+  # "rest.listeners": "http://0.0.0.0:9021"
+
+## Kafka Connect JVM Heap Option
+heapOptions: "-Xms512M -Xmx512M"
+
+## Additional env variables
+customEnv: {}
+
+resources: {}
+  # We usually recommend not to specify default resources and to leave this as a conscious
+  # choice for the user. This also increases chances charts run on environments with little
+  # resources, such as Minikube. If you do want to specify resources, uncomment the following
+  # lines, adjust them as necessary, and remove the curly braces after 'resources:'.
+  # limits:
+  #  cpu: 100m
+  #  memory: 128Mi
+  # requests:
+  #  cpu: 100m
+  #  memory: 128Mi
+
+## Custom pod annotations
+podAnnotations: {}
+
+## Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+nodeSelector: {}
+
+## Taints to tolerate on node assignment:
+## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: {}
+
+## Monitoring
+## Kafka JMX Settings
+## ref: https://docs.confluent.io/current/kafka/monitoring.html
+jmx:
+  port: 5555
+
+## Prometheus Exporter Configuration
+## ref: https://prometheus.io/docs/instrumenting/exporters/
+prometheus:
+  ## JMX Exporter Configuration
+  ## ref: https://github.com/prometheus/jmx_exporter
+  jmx:
+    enabled: true
+    image: solsson/kafka-prometheus-jmx-exporter@sha256
+    imageTag: 6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143
+    port: 5556
+
+    ## Resources configuration for the JMX exporter container.
+    ## See the `resources` documentation above for details.
+    resources: {}
+
+## You can list load balanced service endpoint, or list of all brokers (which is hard in K8s).  e.g.:
+## bootstrapServers: "PLAINTEXT://dozing-prawn-kafka-headless:9092"
+kafka:
+  bootstrapServers: ""
+
+## If the Kafka Chart is disabled a URL and port are required to connect
+## e.g. gnoble-panther-cp-schema-registry:8081
+cp-schema-registry:
+  url: ""
+
+cp-kafka-connect:
+  url: ""
+
+cp-ksql-server:
+  url: ""
+
+cp-zookeeper:
+  ## If the Zookeeper Chart is disabled a URL and port are required to connect
+  url: ""  

--- a/charts/cp-kafka/templates/_helpers.tpl
+++ b/charts/cp-kafka/templates/_helpers.tpl
@@ -68,6 +68,15 @@ external advertised listeners if configurationOverrides.advertised.listeners is 
 {{- end -}}
 
 {{/*
+Create a default fully qualified kafka headless name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "cp-kafka.cp-kafka-headless.fullname" -}}
+{{- $name := "cp-kafka-headless" -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Create a variable containing all the datadirs created.
 */}}
 

--- a/charts/cp-kafka/templates/statefulset.yaml
+++ b/charts/cp-kafka/templates/statefulset.yaml
@@ -110,6 +110,10 @@ spec:
           value: {{ include "cp-kafka.cp-zookeeper.service-name" . | quote }}
         - name: KAFKA_LOG_DIRS
           value: {{ include "cp-kafka.log.dirs" . | quote }}
+        - name: KAFKA_METRIC_REPORTERS
+          value: "io.confluent.metrics.reporter.ConfluentMetricsReporter"
+        - name: CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS
+          value: {{ printf "PLAINTEXT://%s:9092" (include "cp-kafka.cp-kafka-headless.fullname" .) | quote }}
         {{- range $key, $value := .Values.configurationOverrides }}
         - name: {{ printf "KAFKA_%s" $key | replace "." "_" | upper | quote }}
           value: {{ $value | quote }}

--- a/charts/cp-kafka/values.yaml
+++ b/charts/cp-kafka/values.yaml
@@ -11,7 +11,7 @@ brokers: 3
 
 ## Image Info
 ## ref: https://hub.docker.com/r/confluentinc/cp-kafka/
-image: confluentinc/cp-kafka
+image: confluentinc/cp-enterprise-kafka
 imageTag: 5.2.0
 
 ## Specify a imagePullPolicy
@@ -54,6 +54,8 @@ configurationOverrides:
 
 ## Additional env variables
 customEnv: {}
+  # KAFKA_METRIC_REPORTERS: "io.confluent.metrics.reporter.ConfluentMetricsReporter"
+  # CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: "localhost:9092"
 
 persistence:
   enabled: true

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -23,3 +23,7 @@ dependencies:
   version: 0.1.0
   repository: file://./charts/cp-ksql-server
   condition: cp-ksql-server.enabled
+- name: cp-control-center
+  version: 0.1.0
+  repository: file://./charts/cp-control-center
+  condition: cp-control-center.enabled

--- a/values.yaml
+++ b/values.yaml
@@ -17,11 +17,11 @@ cp-zookeeper:
     ## production servers this number should likely be much larger.
     ##
     ## Size for Data dir, where ZooKeeper will store the in-memory database snapshots.
-    dataDirSize: 5Gi
+    dataDirSize: 10Gi
     # dataDirStorageClass: ""
 
     ## Size for data log dir, which is a dedicated log device to be used, and helps avoid competition between logging and snaphots.
-    dataLogDirSize: 5Gi
+    dataLogDirSize: 10Gi
     # dataLogDirStorageClass: ""
   resources: {}
   ## If you do want to specify resources, uncomment the following lines, adjust them as necessary,
@@ -39,7 +39,7 @@ cp-zookeeper:
 cp-kafka:
   enabled: true
   brokers: 3
-  image: confluentinc/cp-kafka
+  image: confluentinc/cp-enterprise-kafka
   imageTag: 5.2.0
   ## Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
   ## https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
@@ -141,3 +141,25 @@ cp-ksql-server:
   heapOptions: "-Xms512M -Xmx512M"
   ksql:
     headless: false
+
+## ------------------------------------------------------
+## Control Center
+## ------------------------------------------------------
+cp-control-center:
+  enabled: true
+  image: confluentinc/cp-enterprise-control-center
+  imageTag: 5.2.0
+  ## Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
+  ## https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
+  imagePullSecrets:
+  #  - name: "regcred"
+  heapOptions: "-Xms512M -Xmx512M"
+  resources: {}
+  ## If you do want to specify resources, uncomment the following lines, adjust them as necessary,
+  ## and remove the curly braces after 'resources:'
+  #  limits:
+  #   cpu: 100m
+  #   memory: 128Mi
+  #  requests:
+  #   cpu: 100m
+  #   memory: 128Mi


### PR DESCRIPTION
## What changes were proposed in this pull request?
* add Confluent Control Center
1 side effect: have to use cp-enterprise-kafka image, otherwise it would show ConfluentMetricsReporter ClassNotFoundException. This could be reverted if the upstream docker image of cp-kafka has ConfluentMetricsReporter included.

## How was this patch tested?

helm upgrade/install on gke, k8s v1.11.7-gke.12
