### PR TITLE
Added Helm chart for kafka-connect, kafka-rest and schema-registry

### DIFF
--- a/charts/cp-kafka-connect/README.md
+++ b/charts/cp-kafka-connect/README.md
@@ -103,6 +103,17 @@ The configuration parameters in this section control the resources requested and
 | --------- | ----------- | ------- |
 | `servicePort` | The port on which the Kafka Connect will be available and serving requests. | `8082` |
 
+### Ingress
+
+| Parameter                        | Description                                | Default                                                 |
+| -------------------------------- | ------------------------------------------ | ------------------------------------------------------- |
+| `ingress.enabled`                | Enable ingress controller resource         | `false`                                                 |
+| `ingress.annotations`            | Ingress annotations                        | `[]`                                                    |
+| `ingress.hosts[0].name`          | Hostname of your installation              | `chart-example.local`                                   |
+| `ingress.hosts[0].path`          | Path within the url structure              | `/`                                                     |
+| `ingress.tls[0].hosts[0]`        | TLS hosts                                  | `chart-example.local`                                   |
+| `ingress.tls[0].secretName`      | TLS Secret (certificates)                  | `chart-example-tls`                                     |
+
 ### Kafka Connect Worker Configurations
 
 | Parameter | Description | Default |

--- a/charts/cp-kafka-connect/templates/ingress.yaml
+++ b/charts/cp-kafka-connect/templates/ingress.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "cp-kafka-connect.fullname" . -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app.kubernetes.io/name: {{ include "cp-kafka-connect.name" . }}
+    helm.sh/chart: {{ include "cp-kafka-connect.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -93,3 +93,17 @@ kafka:
 ## e.g. gnoble-panther-cp-schema-registry:8081
 cp-schema-registry:
   url: ""
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local

--- a/charts/cp-kafka-rest/README.md
+++ b/charts/cp-kafka-rest/README.md
@@ -162,6 +162,17 @@ The configuration parameters in this section control the resources requested and
 | `external.externalTrafficPolicy` | Configures `.spec.externalTrafficPolicy` which controls if load balancing occurs across all nodes (value of `Cluster`) or only active nodes (value of `Local`)  | `Cluster` |
 | `external.loadBalancerSourceRanges` | Configures `.spec.loadBalancerSourceRanges` which controls a list of source IP ranges permitted access to the load balancer | `["0.0.0.0/0"]` |
 
+### Ingress
+
+| Parameter                        | Description                                | Default                                                 |
+| -------------------------------- | ------------------------------------------ | ------------------------------------------------------- |
+| `ingress.enabled`                | Enable ingress controller resource         | `false`                                                 |
+| `ingress.annotations`            | Ingress annotations                        | `[]`                                                    |
+| `ingress.hosts[0].name`          | Hostname of your installation              | `chart-example.local`                                   |
+| `ingress.hosts[0].path`          | Path within the url structure              | `/`                                                     |
+| `ingress.tls[0].hosts[0]`        | TLS hosts                                  | `chart-example.local`                                   |
+| `ingress.tls[0].secretName`      | TLS Secret (certificates)                  | `chart-example-tls`                                     |
+
 ### Deployment Topology
 
 | Parameter | Description | Default |

--- a/charts/cp-kafka-rest/templates/ingress.yaml
+++ b/charts/cp-kafka-rest/templates/ingress.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "cp-kafka-rest.fullname" . -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app.kubernetes.io/name: {{ include "cp-kafka-rest.name" . }}
+    helm.sh/chart: {{ include "cp-kafka-rest.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/cp-kafka-rest/values.yaml
+++ b/charts/cp-kafka-rest/values.yaml
@@ -89,3 +89,17 @@ cp-zookeeper:
 ## e.g. gnoble-panther-cp-schema-registry:8081
 cp-schema-registry:
   url: ""
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local

--- a/charts/cp-schema-registry/README.md
+++ b/charts/cp-schema-registry/README.md
@@ -112,6 +112,17 @@ The configuration parameters in this section control the resources requested and
 | --------- | ----------- | ------- |
 | `servicePort` | The port on which the Schema Registry will be available and serving requests. | `8081` |
 
+### Ingress
+
+| Parameter                        | Description                                | Default                                                 |
+| -------------------------------- | ------------------------------------------ | ------------------------------------------------------- |
+| `ingress.enabled`                | Enable ingress controller resource         | `false`                                                 |
+| `ingress.annotations`            | Ingress annotations                        | `[]`                                                    |
+| `ingress.hosts[0].name`          | Hostname of your installation              | `chart-example.local`                                   |
+| `ingress.hosts[0].path`          | Path within the url structure              | `/`                                                     |
+| `ingress.tls[0].hosts[0]`        | TLS hosts                                  | `chart-example.local`                                   |
+| `ingress.tls[0].secretName`      | TLS Secret (certificates)                  | `chart-example-tls`                                     |
+
 ### Kafka
 
 | Parameter | Description | Default |

--- a/charts/cp-schema-registry/templates/ingress.yaml
+++ b/charts/cp-schema-registry/templates/ingress.yaml
@@ -1,0 +1,39 @@
+{{- if .Values.ingress.enabled -}}
+{{- $fullName := include "cp-schema-registry.fullname" . -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $fullName }}
+  labels:
+    app.kubernetes.io/name: {{ include "cp-schema-registry.name" . }}
+    helm.sh/chart: {{ include "cp-schema-registry.chart" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+{{- if .Values.ingress.tls }}
+  tls:
+  {{- range .Values.ingress.tls }}
+    - hosts:
+      {{- range .hosts }}
+        - {{ . | quote }}
+      {{- end }}
+      secretName: {{ .secretName }}
+  {{- end }}
+{{- end }}
+  rules:
+  {{- range .Values.ingress.hosts }}
+    - host: {{ .host | quote }}
+      http:
+        paths:
+        {{- range .paths }}
+          - path: {{ . }}
+            backend:
+              serviceName: {{ $fullName }}
+              servicePort: http
+        {{- end }}
+  {{- end }}
+{{- end }}

--- a/charts/cp-schema-registry/values.yaml
+++ b/charts/cp-schema-registry/values.yaml
@@ -83,3 +83,17 @@ prometheus:
     port: 5556
 
     resources: {}
+
+ingress:
+  enabled: false
+  annotations: {}
+    # kubernetes.io/ingress.class: nginx
+    # kubernetes.io/tls-acme: "true"
+  hosts:
+    - host: chart-example.local
+      paths: []
+
+  tls: []
+  #  - secretName: chart-example-tls
+  #    hosts:
+  #      - chart-example.local


### PR DESCRIPTION
Signed-off-by: Keyvan Hedayati <k1.hedayati93@gmail.com>

## What changes were proposed in this pull request?

Added Helm chart for kafka-connect, kafka-rest and schema-registry which is mentioned in #119

## How was this patch tested?

It's the default template generated by `helm create` and it's safe
