### PR TITLE
Use simpler and proper way to get headless kafka name

### DIFF
--- a/charts/cp-kafka/templates/_helpers.tpl
+++ b/charts/cp-kafka/templates/_helpers.tpl
@@ -72,8 +72,7 @@ Create a default fully qualified kafka headless name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "cp-kafka.cp-kafka-headless.fullname" -}}
-{{- $name := "cp-kafka-headless" -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-headless" (include "cp-kafka.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
Signed-off-by: Keyvan Hedayati <k1.hedayati93@gmail.com>

## What changes were proposed in this pull request?

In case the release name is `cp-kafka` the current logic will break and Kafka will not be deployed successfully. This commit fixes that in a simple way.

## How was this patch tested?

Helm upgrade on minikube
