### PR TITLE
Kafka Connect hostAlias and secret mount entries

### DIFF
--- a/charts/cp-kafka-connect/README.md
+++ b/charts/cp-kafka-connect/README.md
@@ -162,6 +162,18 @@ The configuration parameters in this section control the resources requested and
 | `hostAlias.elasticsearch.ipAddress`| IP address of Elasticsearch server. | `10.10.10.10`
 | `hostAlias.elasticsearch.hostName`| Host name of Elasticsearch server. | `elasticsearch`
 
+### Secrets mount for certificates
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `secretMount.enabled` | Enable mounting a secret volume. | `false`
+| `secretMount.certs.secretName`| Secret name. Secret must be in the same namespace as Kafka deployment. | `logging-elk-certs`
+| `secretMount.certs.mountPath`| Mount path in container. | `/opt/certs`
+
+If you have existing secret in some namespace, use following command to copy it to another namespace:
+
+`kubectl get secret logging-elk-certs --namespace=kube-system --export -o yaml | kubectl apply --namespace=kafka -f -`
+
 ## Dependencies
 
 ### Kafka

--- a/charts/cp-kafka-connect/README.md
+++ b/charts/cp-kafka-connect/README.md
@@ -154,6 +154,14 @@ The configuration parameters in this section control the resources requested and
 | `nodeSelector` | Dictionary containing key-value-pairs to match labels on nodes. When defined pods will only be scheduled on nodes, that have each of the indicated key-value pairs as labels. Further information can be found in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) | `{}`
 | `tolerations`| Array containing taint references. When defined, pods can run on nodes, which would otherwise deny scheduling. Further information can be found in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) | `{}`
 
+### Host alias for Elasticsearch server
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `hostAlias.enabled` | Enable [hostAliases](https://kubernetes.io/docs/concepts/services-networking/add-entries-to-pod-etc-hosts-with-host-aliases/) entry in deployment. | `false`
+| `hostAlias.elasticsearch.ipAddress`| IP address of Elasticsearch server. | `10.10.10.10`
+| `hostAlias.elasticsearch.hostName`| Host name of Elasticsearch server. | `elasticsearch`
+
 ## Dependencies
 
 ### Kafka

--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -29,6 +29,12 @@ spec:
       {{- end }}
       {{- end }}
     spec:
+      {{- if .Values.hostAlias.enabled }}
+      hostAliases:
+      - ip: {{ .Values.hostAlias.elasticsearch.ipAddress | quote }}
+        hostnames:
+        - {{ .Values.hostAlias.elasticsearch.hostName | quote }}
+      {{- end }}
       containers:
         {{- if .Values.prometheus.jmx.enabled }}
         - name: prometheus-jmx-exporter

--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -70,6 +70,12 @@ spec:
             {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+          {{- if .Values.secretMount.enabled }}
+          volumeMounts:
+          - name: certs
+            mountPath: {{ .Values.secretMount.certs.mountPath | quote }}
+            readOnly: true
+          {{- end }}
           env:
             - name: CONNECT_REST_ADVERTISED_HOST_NAME
               valueFrom:
@@ -108,6 +114,12 @@ spec:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
       {{- end }}
       volumes:
+      {{- if .Values.secretMount.enabled }}
+      - name: certs
+        secret:
+          defaultMode: 420
+          secretName: {{ .Values.secretMount.certs.secretName | quote }}
+      {{- end }}
       {{- if .Values.prometheus.jmx.enabled }}
       - name: jmx-config
         configMap:

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -103,3 +103,9 @@ hostAlias:
     ipAddress: 10.10.10.10
     hostName: elasticsearch
   
+## Mount secrets as directories
+secretMount:
+  enabled: false
+  certs:
+    secretName: logging-elk-certs
+    mountPath: /opt/certs

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -93,3 +93,13 @@ kafka:
 ## e.g. gnoble-panther-cp-schema-registry:8081
 cp-schema-registry:
   url: ""
+
+## Host aliases
+## Added to Kafka Connect container hosts file
+hostAlias:
+  enabled: false
+  ## Elasticsearch server host alias
+  elasticsearch:    
+    ipAddress: 10.10.10.10
+    hostName: elasticsearch
+  


### PR DESCRIPTION
## What changes were proposed in this pull request?

Parameters to enable and configure hostAlias for Elasticsearch and secret mount for Elasticsearch certificates. 

Secret mount is used when connecting to Elasticsearch that requires client authentication.

Host alias is used when connecting to Elasticsearch running in a different namespace than Kafka.

## How was this patch tested?

Helm install/upgrade on IBM Cloud Private.
