### PR TITLE
Fix control center resources template

### DIFF
--- a/charts/cp-control-center/templates/deployment.yaml
+++ b/charts/cp-control-center/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
               containerPort: {{ .Values.serviceHttpPort}}
               protocol: TCP
           resources:
-{{- toYaml .Values.resources | indent 12 }}
+{{ toYaml .Values.resources | indent 12 }}
           env:
             - name: CONTROL_CENTER_BOOTSTRAP_SERVERS
               value: {{ template "cp-control-center.kafka.bootstrapServers" . }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

I've changed the control center template to fix this error I was getting when trying to add the control center chart:

```
Error: YAML parse error on cp-helm-charts/charts/cp-control-center/templates/deployment.yaml: error converting YAML to JSON: yaml: line 32: mapping values are not allowed in this context
```

## How was this patch tested?

Creating the control center deployment and even just by looking at the other usages of `toYaml .Values.resources` they're not using `{{-` but `{{`