### PR TITLE
plugin path is not pointing to right directory

### DIFF
--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -23,7 +23,7 @@ servicePort: 8083
 ## Kafka Connect properties
 ## ref: https://docs.confluent.io/current/connect/userguide.html#configuring-workers
 configurationOverrides:
-  "plugin.path": "/usr/share/confluent-hub-components"
+  "plugin.path": "/usr/share/java,/usr/share/confluent-hub-components"
   "key.converter": "io.confluent.connect.avro.AvroConverter"
   "value.converter": "io.confluent.connect.avro.AvroConverter"
   "key.converter.schemas.enable": "false"

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -23,7 +23,7 @@ servicePort: 8083
 ## Kafka Connect properties
 ## ref: https://docs.confluent.io/current/connect/userguide.html#configuring-workers
 configurationOverrides:
-  "plugin.path": "/usr/share/java"
+  "plugin.path": "/usr/share/confluent-hub-components"
   "key.converter": "io.confluent.connect.avro.AvroConverter"
   "value.converter": "io.confluent.connect.avro.AvroConverter"
   "key.converter.schemas.enable": "false"


### PR DESCRIPTION

## What changes were proposed in this pull request?

Currently the plugin path points `/usr/share/java`, and container are created looking for plugins inside this directory.
But when we install plugin using `confluent-hub install --no-prompt confluentinc/kafka-connect-replicator:latest` 
it installs them in the `/usr/share/confluent-hub-components`

Customers are creating connect clusters using DockerFile images like this 
`FROM confluentinc/cp-kafka-connect-base:5.2.1
RUN   confluent-hub install --no-prompt confluentinc/kafka-connect-replicator:latest`

But when they get the cluster in kubernetes they only see filestream connectors installed as its looking inside /usr/share/java and not /usr/share/confluent-hub-components

## How was this patch tested?

i have tested it in on gke. 
