### PR TITLE
add support for alternate scheduler

### DIFF
--- a/charts/cp-kafka/README.md
+++ b/charts/cp-kafka/README.md
@@ -142,6 +142,11 @@ The configuration parameters in this section control the resources requested and
 | `persistence.storageClass` | Valid options: `nil`, `"-"`, or storage class name. | `nil` |
 | `persistence.disksPerBroker` | The amount of disks that will be attached per instance of Kafka broker. | 1 |
 
+### Scheduler
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `schedulerName` | Alternate scheduler name | `nil` |
+
 ### Kafka JVM Heap Options
 
 | Parameter | Description | Default |
@@ -206,3 +211,4 @@ The configuration parameters in this section control the resources requested and
 | `cp-zookeeper.persistence.dataLogDirSize` | Size for data log dir, which is a dedicated log device to be used, and helps avoid competition between logging and snapshots. This will overwrite corresponding value in cp-zookeeper chart's value.yaml. | `5Gi` |
 | `cp-zookeeper.url` | Service name of Zookeeper cluster (Not needed if zookeeper.enabled is set to true). | `""` |
 | `cp-zookeeper.clientPort` | Port of Zookeeper Cluster | `2181` |
+| `cp-zookeeper.schedulerName`   | Alternate scheduler nane  | `nil`  |

--- a/charts/cp-kafka/templates/statefulset.yaml
+++ b/charts/cp-kafka/templates/statefulset.yaml
@@ -29,6 +29,9 @@ spec:
       {{- end }}
       {{- end }}
     spec:
+      {{- if .Values.schedulerName }}
+      schedulerName: "{{ .Values.schedulerName }}"
+      {{- end }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/charts/cp-kafka/values.yaml
+++ b/charts/cp-kafka/values.yaml
@@ -127,6 +127,11 @@ nodeport:
   servicePort: 19092
   firstListenerPort: 31090
 
+## Use an alternate scheduler.
+## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+##
+## schedulerName: ""
+
 ## ------------------------------------------------------
 ## Zookeeper
 ## ------------------------------------------------------
@@ -142,3 +147,8 @@ cp-zookeeper:
 
   ## If the Zookeeper Chart is disabled a URL and port are required to connect
   url: ""
+
+  ## Use an alternate scheduler.
+  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  ## schedulerName: ""

--- a/charts/cp-zookeeper/README.md
+++ b/charts/cp-zookeeper/README.md
@@ -155,6 +155,11 @@ The configuration parameters in this section control the resources requested and
 | `persistence.dataLogDirSize` | Size for data log dir, which is a dedicated log device to be used, and helps avoid competition between logging and snaphots. | `5Gi` |
 | `persistence.dataLogDirStorageClass` | Valid options: `nil`, `"-"`, or storage class name. | `nil` |
 
+### Scheduler
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `schedulerName` | Alternate scheduler name | `nil` |
+
 ### Resources
 
 | Parameter | Description | Default |

--- a/charts/cp-zookeeper/templates/statefulset.yaml
+++ b/charts/cp-zookeeper/templates/statefulset.yaml
@@ -29,6 +29,9 @@ spec:
       {{- end }}
       {{- end }}
     spec:
+      {{- if .Values.schedulerName }}
+      schedulerName: "{{ .Values.schedulerName }}"
+      {{- end }}
       affinity:
         podAntiAffinity:
           preferredDuringSchedulingIgnoredDuringExecution:

--- a/charts/cp-zookeeper/values.yaml
+++ b/charts/cp-zookeeper/values.yaml
@@ -21,7 +21,7 @@ imageTag: 5.2.1
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
 imagePullPolicy: IfNotPresent
 
-## Specify an array of imagePullSecrets. 
+## Specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.
 ## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
 imagePullSecrets:
@@ -70,6 +70,10 @@ persistence:
   dataLogDirSize: 5Gi
   # dataLogDirStorageClass: ""
 
+## Use an alternate scheduler.
+## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+##
+## schedulerName: ""
 
 ## Pod Compute Resources
 ## ref: https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/

--- a/values.yaml
+++ b/values.yaml
@@ -33,6 +33,11 @@ cp-zookeeper:
   #   cpu: 100m
   #   memory: 128Mi
 
+  ## Use an alternate scheduler.
+  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  ## schedulerName: ""
+
 ## ------------------------------------------------------
 ## Kafka
 ## ------------------------------------------------------
@@ -60,6 +65,11 @@ cp-kafka:
   #  requests:
   #   cpu: 100m
   #   memory: 128Mi
+
+  ## Use an alternate scheduler.
+  ## ref: https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/
+  ##
+  ## schedulerName: ""
 
 ## ------------------------------------------------------
 ## Schema Registry


### PR DESCRIPTION
Signed-off-by: Sathya Balakrishnan <sathya@portworx.com>

## What changes were proposed in this pull request?
This PR adds support for specifying an alternate scheduler https://kubernetes.io/docs/tasks/administer-cluster/configure-multiple-schedulers/

## How was this patch tested?
Tested on AKS, running kubernetes 1.13.5 as well as vanilla kubernetes v 1.14.1
```helm install --name confluent --debug --set cp-zookeeper.persistence.dataDirStorageClass=portworx-sc,cp-zookeeper.schedulerName=stork,cp-kafka.persistence.storageClass=portworx-sc,cp-kafka.schedulerName=stork .```