### PR TITLE
Add envFrom parameter in Deployments and StatefulSets

### DIFF
--- a/charts/cp-control-center/templates/deployment.yaml
+++ b/charts/cp-control-center/templates/deployment.yaml
@@ -39,6 +39,7 @@ spec:
               protocol: TCP
           resources:
 {{- toYaml .Values.resources | indent 12 }}
+          envFrom: {{ .Values.envFrom }}
           env:
             - name: CONTROL_CENTER_BOOTSTRAP_SERVERS
               value: {{ template "cp-control-center.kafka.bootstrapServers" . }}

--- a/charts/cp-control-center/values.yaml
+++ b/charts/cp-control-center/values.yaml
@@ -38,6 +38,10 @@ heapOptions: "-Xms512M -Xmx512M"
 ## Additional env variables
 customEnv: {}
 
+## Additional environment variables from ConfigMap or Secret
+## Ref: https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables
+envFrom: []
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/charts/cp-kafka-connect/README.md
+++ b/charts/cp-kafka-connect/README.md
@@ -109,6 +109,7 @@ The configuration parameters in this section control the resources requested and
 | --------- | ----------- | ------- |
 | `configurationOverrides` | Kafka Connect [configuration](https://docs.confluent.io/current/connect/references/allconfigs.html) overrides in the dictionary format. | `{}` |
 | `customEnv` | Custom environmental variables | `{}` |
+| `envFrom` | Custom environment variables from Secret or ConfigMap [configuration](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables) | `[]` |
 
 ### Kafka Connect JVM Heap Options
 

--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -65,6 +65,7 @@ spec:
             {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+          envFrom: {{ .Values.envFrom }}
           env:
             - name: CONNECT_REST_ADVERTISED_HOST_NAME
               valueFrom:

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -40,6 +40,10 @@ heapOptions: "-Xms512M -Xmx512M"
 ## Additional env variables
 customEnv: {}
 
+## Additional environment variables from ConfigMap or Secret
+## Ref: https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables
+envFrom: []
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little

--- a/charts/cp-kafka-rest/README.md
+++ b/charts/cp-kafka-rest/README.md
@@ -113,6 +113,7 @@ The configuration parameters in this section control the resources requested and
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `configurationOverrides` | Kafka REST [configuration](https://docs.confluent.io/current/kafka-rest/docs/config.html) overrides in the dictionary format | `{}` |
+| `envFrom` | Custom environment variables from Secret or ConfigMap [configuration](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables) | `[]` |
 
 ### Confluent Kafka REST JVM Heap Options
 

--- a/charts/cp-kafka-rest/templates/deployment.yaml
+++ b/charts/cp-kafka-rest/templates/deployment.yaml
@@ -65,6 +65,7 @@ spec:
             {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+          envFrom: {{ .Values.envFrom }}
           env:
           - name: KAFKA_REST_HOST_NAME
             valueFrom:

--- a/charts/cp-kafka-rest/values.yaml
+++ b/charts/cp-kafka-rest/values.yaml
@@ -51,6 +51,10 @@ tolerations: {}
 configurationOverrides:
   # "consumer.request.timeout.ms": 5000
 
+## Additional environment variables from ConfigMap or Secret
+## Ref: https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables
+envFrom: []
+
 ## Monitoring
 ## Kafka REST JMX Settings
 ## ref: https://docs.confluent.io/current/kafka-rest/docs/monitoring.html

--- a/charts/cp-kafka/README.md
+++ b/charts/cp-kafka/README.md
@@ -132,6 +132,7 @@ The configuration parameters in this section control the resources requested and
 | --------- | ----------- | ------- |
 | `configurationOverrides` | Kafka [configuration](https://kafka.apache.org/documentation/#brokerconfigs) overrides in the dictionary format | `{}` |
 | `customEnv` | Custom environmental variables | `{}` |
+| `envFrom` | Custom environment variables from Secret or ConfigMap [configuration](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables) | `[]` |
 
 ### Persistence
 

--- a/charts/cp-kafka/templates/statefulset.yaml
+++ b/charts/cp-kafka/templates/statefulset.yaml
@@ -88,6 +88,7 @@ spec:
         {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+        envFrom: {{ .Values.envFrom }}
         env:
         - name: POD_IP
           valueFrom:

--- a/charts/cp-kafka/values.yaml
+++ b/charts/cp-kafka/values.yaml
@@ -57,6 +57,10 @@ customEnv: {}
   # KAFKA_METRIC_REPORTERS: "io.confluent.metrics.reporter.ConfluentMetricsReporter"
   # CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: "localhost:9092"
 
+## Additional environment variables from ConfigMap or Secret
+## Ref: https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables
+envFrom: []
+
 persistence:
   enabled: true
 

--- a/charts/cp-ksql-server/README.md
+++ b/charts/cp-ksql-server/README.md
@@ -116,6 +116,7 @@ The configuration parameters in this section control the resources requested and
  Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `configurationOverrides` | KSQL [configuration](https://docs.confluent.io/current/ksql/docs/installation/server-config/config-reference.html) overrides in the dictionary format | `{}` |
+| `envFrom` | Custom environment variables from Secret or ConfigMap [configuration](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables) | `[]` |
 
 ### Port
 

--- a/charts/cp-ksql-server/templates/deployment.yaml
+++ b/charts/cp-ksql-server/templates/deployment.yaml
@@ -70,6 +70,7 @@ spec:
           - name: ksql-queries
             mountPath: /etc/ksql/queries
           {{- end }}
+          envFrom: {{ .Values.envFrom }}
           env:
           - name: KSQL_BOOTSTRAP_SERVERS
             value: {{ template "cp-ksql-server.kafka.bootstrapServers" . }}

--- a/charts/cp-ksql-server/values.yaml
+++ b/charts/cp-ksql-server/values.yaml
@@ -94,3 +94,7 @@ cp-schema-registry:
 ## ref: https://docs.confluent.io/current/ksql/docs/installation/server-config/config-reference.html
 configurationOverrides: {}
   # "ksql.streams.producer.retries": "2147483647"
+
+## Additional environment variables from ConfigMap or Secret
+## Ref: https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables
+envFrom: []

--- a/charts/cp-schema-registry/README.md
+++ b/charts/cp-schema-registry/README.md
@@ -105,6 +105,7 @@ The configuration parameters in this section control the resources requested and
 | --------- | ----------- | ------- |
 | `configurationOverrides` | Schema Registry [configuration](https://docs.confluent.io/current/schema-registry/docs/config.html) overrides in the dictionary format. | `{}` |
 | `customEnv` | Custom environmental variables | `{}` |
+| `envFrom` | Custom environment variables from Secret or ConfigMap [configuration](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables) | `[]` |
 
 ### Port
 

--- a/charts/cp-schema-registry/templates/deployment.yaml
+++ b/charts/cp-schema-registry/templates/deployment.yaml
@@ -65,6 +65,7 @@ spec:
             {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+          envFrom: {{ .Values.envFrom }}
           env:
           - name: SCHEMA_REGISTRY_HOST_NAME
             valueFrom:

--- a/charts/cp-schema-registry/values.yaml
+++ b/charts/cp-schema-registry/values.yaml
@@ -30,6 +30,10 @@ configurationOverrides: {}
 ## Additional env variables
 customEnv: {}
 
+## Additional environment variables from ConfigMap or Secret
+## Ref: https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables
+envFrom: []
+
 ## The port on which the Schema Registry will be available and serving requests
 servicePort: 8081
 

--- a/charts/cp-zookeeper/README.md
+++ b/charts/cp-zookeeper/README.md
@@ -130,6 +130,7 @@ The configuration parameters in this section control the resources requested and
 | `maxClientCnxns` | Limits the number of concurrent connections (at the socket level) that a single client, identified by IP address, may make to a single member of the ZooKeeper ensemble. This is used to prevent certain classes of DoS attacks, including file descriptor exhaustion. | `60` |
 | `autoPurgeSnapRetainCount` | When enabled, ZooKeeper auto purge feature retains the autopurge.snapRetainCount most recent snapshots and the corresponding transaction logs in the dataDir and dataLogDir respectively and deletes the rest. | `3` |
 | `autoPurgePurgeInterval` | The time interval in hours for which the purge task has to be triggered. Set to a positive integer (1 and above) to enable the auto purging. | `72` |
+| `envFrom` | Custom environment variables from Secret or ConfigMap [configuration](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables) | `[]` |
 
 ### Zookeeper JVM Heap Options
 

--- a/charts/cp-zookeeper/templates/statefulset.yaml
+++ b/charts/cp-zookeeper/templates/statefulset.yaml
@@ -84,6 +84,7 @@ spec:
         {{- end }}
         resources:
 {{ toYaml .Values.resources | indent 10 }}
+        envFrom: {{ .Values.envFrom }}
         env:
         - name : KAFKA_HEAP_OPTS
           value: "{{ .Values.heapOptions }}"

--- a/charts/cp-zookeeper/values.yaml
+++ b/charts/cp-zookeeper/values.yaml
@@ -45,6 +45,10 @@ maxClientCnxns: 60
 autoPurgeSnapRetainCount: 3
 autoPurgePurgeInterval: 24
 
+## Additional environment variables from ConfigMap or Secret
+## Ref: https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables
+envFrom: []
+
 ## Zookeeper JVM Heap Option
 heapOptions: "-Xms512M -Xmx512M"
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds the [envFrom](https://kubernetes.io/docs/tasks/inject-data-application/distribute-credentials-secure/#configure-all-key-value-pairs-in-a-secret-as-container-environment-variables) parameter for Deployments and Daemonsets. This allows to setup environment parameters from external secrets

## How was this patch tested?

helm install on EKS
