### PR TITLE
Update statefulset.yaml

### DIFF
--- a/charts/cp-kafka/templates/statefulset.yaml
+++ b/charts/cp-kafka/templates/statefulset.yaml
@@ -139,10 +139,12 @@ spec:
           export KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://${POD_NAME}.{{ template "cp-kafka.fullname" . }}-headless.${POD_NAMESPACE}:9092{{ include "cp-kafka.configuration.advertised.listeners" . }} && \
           exec /etc/confluent/docker/run
         volumeMounts:
-        {{- $disksPerBroker := .Values.persistence.disksPerBroker | int }}
-        {{- range $k, $e := until $disksPerBroker }}
-        - name: datadir-{{$k}}
-          mountPath: /opt/kafka/data-{{$k}}
+        {{- if .Values.persistence.enabled }}
+          {{- $disksPerBroker := .Values.persistence.disksPerBroker | int }}
+          {{- range $k, $e := until $disksPerBroker }}
+          - name: datadir-{{$k}}
+            mountPath: /opt/kafka/data-{{$k}}
+          {{- end }}
         {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
Fixing https://github.com/confluentinc/cp-helm-charts/issues/319 

If Values(.cp-kafka).persistence.enabled=false there shouldn't be "datadir-x" volumeMount. 
Current version fails to create kafka-cp-kafka for that reason withe the following error: 
	create Pod kafka-cp-kafka-0 in StatefulSet kafka-cp-kafka failed error: Pod "kafka-cp-kafka-0" is invalid: spec.containers[2].volumeMounts[1].name: Not found: "datadir-0"

## What changes were proposed in this pull request?

Added a condition in the chart to allow proper deploy when setting 
Values(.cp-kafka).persistence.enabled=false

## How was this patch tested?

helm upgrade on k8s cluster
