### PR TITLE
added test for zookeeper

### DIFF
--- a/charts/cp-zookeeper/templates/_helpers.tpl
+++ b/charts/cp-zookeeper/templates/_helpers.tpl
@@ -46,3 +46,16 @@ in a format like "zkhost1:port:port;zkhost2:port:port"
 {{- end }}
 {{- printf "%s" (join ";" $zk.servers) | quote -}}
 {{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "cp-zookeeper.labels" -}}
+app.kubernetes.io/name: {{ include "cp-zookeeper.name" . }}
+helm.sh/chart: {{ include "cp-zookeeper.chart" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end -}}

--- a/charts/cp-zookeeper/templates/headless-service.yaml
+++ b/charts/cp-zookeeper/templates/headless-service.yaml
@@ -3,10 +3,7 @@ kind: Service
 metadata:
   name: {{ template "cp-zookeeper.fullname" . }}-headless
   labels:
-    app: {{ template "cp-zookeeper.name" . }}
-    chart: {{ template "cp-zookeeper.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+  {{ include "cp-zookeeper.labels" . | nindent 4 }}
 spec:
   ports:
     - port: {{ .Values.serverPort }}

--- a/charts/cp-zookeeper/templates/jmx-configmap.yaml
+++ b/charts/cp-zookeeper/templates/jmx-configmap.yaml
@@ -4,10 +4,7 @@ kind: ConfigMap
 metadata:
   name: {{ template "cp-zookeeper.fullname" . }}-jmx-configmap
   labels:
-    app: {{ template "cp-zookeeper.name" . }}
-    chart: {{ template "cp-zookeeper.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+  {{ include "cp-zookeeper.labels" . | nindent 4 }}
 data:
   jmx-zookeeper-prometheus.yml: |+
     jmxUrl: service:jmx:rmi:///jndi/rmi://localhost:{{ .Values.jmx.port }}/jmxrmi

--- a/charts/cp-zookeeper/templates/poddisruptionbudget.yaml
+++ b/charts/cp-zookeeper/templates/poddisruptionbudget.yaml
@@ -3,10 +3,7 @@ kind: PodDisruptionBudget
 metadata:
   name: {{ template "cp-zookeeper.fullname" . }}-pdb
   labels:
-    app: {{ template "cp-zookeeper.name" . }}
-    chart: {{ template "cp-zookeeper.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+  {{ include "cp-zookeeper.labels" . | nindent 4 }}
 spec:
   selector:
     matchLabels:

--- a/charts/cp-zookeeper/templates/service.yaml
+++ b/charts/cp-zookeeper/templates/service.yaml
@@ -3,10 +3,7 @@ kind: Service
 metadata:
   name: {{ template "cp-zookeeper.fullname" . }}
   labels:
-    app: {{ template "cp-zookeeper.name" . }}
-    chart: {{ template "cp-zookeeper.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+  {{ include "cp-zookeeper.labels" . | nindent 4 }}
 spec:
   type: {{ .Values.serviceType }}
   ports:

--- a/charts/cp-zookeeper/templates/statefulset.yaml
+++ b/charts/cp-zookeeper/templates/statefulset.yaml
@@ -3,10 +3,7 @@ kind: StatefulSet
 metadata:
   name: {{ template "cp-zookeeper.fullname" . }}
   labels:
-    app: {{ template "cp-zookeeper.name" . }}
-    chart: {{ template "cp-zookeeper.chart" . }}
-    release: {{ .Release.Name }}
-    heritage: {{ .Release.Service }}
+  {{ include "cp-zookeeper.labels" . | nindent 4 }}
 spec:
   serviceName: {{ template "cp-zookeeper.fullname" . }}-headless
   podManagementPolicy: {{ .Values.podManagementPolicy }}

--- a/charts/cp-zookeeper/templates/tests/test-zk-connection.yaml
+++ b/charts/cp-zookeeper/templates/tests/test-zk-connection.yaml
@@ -1,0 +1,18 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: "{{ include "cp-zookeeper.fullname" . }}-test-connection"
+  labels:
+  {{ include "cp-zookeeper.labels" . | nindent 4 }}
+  annotations:
+    "helm.sh/hook": test-success
+spec:
+  containers:
+  - name: connect-zk-client-port
+    image: busybox
+    command:
+    - "/bin/sh"
+    - "-c"
+    args:
+    - "echo 'ruok' | nc {{ include "cp-zookeeper.fullname" . }} {{ .Values.clientPort }} | grep 'imok'"
+  restartPolicy: Never


### PR DESCRIPTION
## What changes were proposed in this pull request?
- Resolve #22
- Added a helm chart test for zookeeper
- Use common labels helper function from helm 2.14

## How was this patch tested?
- Install zookeeper chart: `cd charts/cp-zookeeper && helm install . --name zk --set servers=1`
- Positive test: wait for pod to be ready `helm test zk`
- Negative test: `kubectl scale statefulset zk-cp-zookeeper --replicas=0 && helm test zk`
