### PR TITLE
offset replication factor based on desired brokers

### DIFF
--- a/charts/cp-kafka/templates/statefulset.yaml
+++ b/charts/cp-kafka/templates/statefulset.yaml
@@ -115,6 +115,10 @@ spec:
           value: "io.confluent.metrics.reporter.ConfluentMetricsReporter"
         - name: CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS
           value: {{ printf "PLAINTEXT://%s:9092" (include "cp-kafka.cp-kafka-headless.fullname" .) | quote }}
+        - name: CONFLUENT_METRICS_REPORTER_TOPIC_REPLICAS
+          value: {{ min .Values.brokers .Values.metricsReplication | quote }}
+        - name: KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR
+          value: {{ min .Values.brokers .Values.offsetsReplication | quote }}
         {{- range $key, $value := .Values.configurationOverrides }}
         - name: {{ printf "KAFKA_%s" $key | replace "." "_" | upper | quote }}
           value: {{ $value | quote }}

--- a/charts/cp-kafka/values.yaml
+++ b/charts/cp-kafka/values.yaml
@@ -35,7 +35,6 @@ updateStrategy: RollingUpdate
 ## Kafka Server properties
 ## ref: https://kafka.apache.org/documentation/#configuration
 configurationOverrides:
-  "offsets.topic.replication.factor": "3"
   # "default.replication.factor": 3
   # "min.insync.replicas": 2
   # "auto.create.topics.enable": false
@@ -56,6 +55,15 @@ configurationOverrides:
 customEnv: {}
   # KAFKA_METRIC_REPORTERS: "io.confluent.metrics.reporter.ConfluentMetricsReporter"
   # CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS: "localhost:9092"
+
+## The replication factor for the offsets topic (set higher to ensure availability). 
+## Internal topic creation will fail until the cluster size meets this replication factor requirement.
+## If desired broker count is lower, will use the broker count
+offsetsReplication: 3
+
+## Number of replicas in the metric topic. It must not be higher than the number of brokers in the Kafka cluster.
+## If desired broker count is lower, will use the broker count
+metricsReplication: 3
 
 persistence:
   enabled: true


### PR DESCRIPTION
## What changes were proposed in this pull request?
- Allow starting a 1 or 2 node Kafka Cluster without setting `configurationOverrides.offsets.topic.replication.factor` explicitely 
- confluent metrics topic is created successfully, when running with less than 3 brokers
- Relates to #236

## How was this patch tested?
- Install with 1 broker: `helm install --name cp . --set cp-zookeeper.servers=1 --set cp-kafka-rest.enabled=false --set cp-ksql-server.enabled=false --set cp-control-center.enabled=false --set cp-kafka.brokers=1  --set cp-kafka-connect.enabled=false --set cp-schema-registry.enabled=false`
- Check logs, that errors are gone