### PR TITLE
Add Kubernetes recomended labels

### DIFF
--- a/charts/cp-zookeeper/templates/statefulset.yaml
+++ b/charts/cp-zookeeper/templates/statefulset.yaml
@@ -3,6 +3,10 @@ kind: StatefulSet
 metadata:
   name: {{ template "cp-zookeeper.fullname" . }}
   labels:
+    helm.sh/chart: {{ include "cp-zookeeper.chart" . }}
+    app.kubernetes.io/name: {{ include "cp-zookeeper.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/managed-by: {{ .Release.Service }}
     app: {{ template "cp-zookeeper.name" . }}
     chart: {{ template "cp-zookeeper.chart" . }}
     release: {{ .Release.Name }}
@@ -16,6 +20,8 @@ spec:
   template:
     metadata:
       labels:
+        app.kubernetes.io/name: {{ include "cp-zookeeper.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
         app: {{ template "cp-zookeeper.name" . }}
         release: {{ .Release.Name }}
       {{- if or .Values.podAnnotations .Values.prometheus.jmx.enabled }}


### PR DESCRIPTION
Use Kubernetes Recomended [Labels](https://kubernetes.io/docs/concepts/overview/working-with-objects/common-labels/) for Stateful Set.

## What changes were proposed in this pull request?

Add Kubernetes Recomended labels to Zookeeper Stateful Set.

## How was this patch tested?

helm install on gke
