### PR TITLE
change apiVersion from apps/v1beta1 to apps/v1

### DIFF
--- a/charts/cp-kafka/templates/statefulset.yaml
+++ b/charts/cp-kafka/templates/statefulset.yaml
@@ -1,4 +1,4 @@
-apiVersion: apps/v1beta1
+apiVersion: apps/v1
 kind: StatefulSet
 metadata:
   name: {{ template "cp-kafka.fullname" . }}


### PR DESCRIPTION
Kubernetes 1.16 had following Changes:

Continued deprecation of extensions/v1beta1, apps/v1beta1, and apps/v1beta2 APIs; these extensions will be retired in 1.16!

## What changes were proposed in this pull request?

change apiVersion from apps/v1beta1 to apps/v1

## How was this patch tested?

local helm install on that repo.
