### PR TITLE
Expose Prometheus metrics port in Kafka-Connect Service

### DIFF
--- a/charts/cp-kafka-connect/templates/service.yaml
+++ b/charts/cp-kafka-connect/templates/service.yaml
@@ -11,6 +11,10 @@ spec:
   ports:
     - name: kafka-connect
       port: {{ .Values.servicePort }}
+{{ if .Values.prometheus.jmx.enabled }}
+    - name: metrics
+      port: {{ .Values.prometheus.jmx.port }}
+  {{ end }}      
   selector:
     app: {{ template "cp-kafka-connect.name" . }}
     release: {{ .Release.Name }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

JMX Prometheus exporter populated _/metrics_ endpoint needs to be exposed for exporting Kafka-Connect data to Prometheus. 

## How was this patch tested?

This was tested using helm install on AWS EKS service
