### PR TITLE
[cp-kafka-connect] Add ServiceAccount

### DIFF
--- a/charts/cp-kafka-connect/README.md
+++ b/charts/cp-kafka-connect/README.md
@@ -103,6 +103,13 @@ The configuration parameters in this section control the resources requested and
 | --------- | ----------- | ------- |
 | `servicePort` | The port on which the Kafka Connect will be available and serving requests. | `8082` |
 
+### ServiceAccount
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `serviceAccount.create` | Specifies whether a ServiceAccount should be created. | `false` |
+| `serviceAccount.name` | The name of the ServiceAccount to use, otherwise a default name is used. | `` |
+
 ### Kafka Connect Worker Configurations
 
 | Parameter | Description | Default |

--- a/charts/cp-kafka-connect/templates/_helpers.tpl
+++ b/charts/cp-kafka-connect/templates/_helpers.tpl
@@ -79,3 +79,14 @@ Default GroupId to Release Name but allow it to be overridden
 {{- .Release.Name -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cp-kafka-connect.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create -}}
+    {{ default (include "cp-kafka-connect.fullname" .) .Values.serviceAccount.name }}
+{{- else -}}
+    {{ default "default" .Values.serviceAccount.name }}
+{{- end -}}
+{{- end -}}

--- a/charts/cp-kafka-connect/templates/_helpers.tpl
+++ b/charts/cp-kafka-connect/templates/_helpers.tpl
@@ -85,7 +85,7 @@ Create the name of the service account to use
 */}}
 {{- define "cp-kafka-connect.serviceAccountName" -}}
 {{- if .Values.serviceAccount.create -}}
-    {{ default (include "cp-kafka-connect.fullname" .) .Values.serviceAccount.name }}
+    {{ default (include "cp-kafka-connect.name" .) .Values.serviceAccount.name }}
 {{- else -}}
     {{ default "default" .Values.serviceAccount.name }}
 {{- end -}}

--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -116,3 +116,6 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       {{- end }}
+      {{- if .Values.serviceAccount.create -}}
+      serviceAccountName: {{ template "cp-kafka-connect.serviceAccountName" . }}
+      {{- end -}}

--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -29,6 +29,9 @@ spec:
       {{- end }}
       {{- end }}
     spec:
+      {{- if .Values.serviceAccount.create }}
+      serviceAccountName: {{ template "cp-kafka-connect.serviceAccountName" . }}
+      {{- end }}
       containers:
         {{- if .Values.prometheus.jmx.enabled }}
         - name: prometheus-jmx-exporter
@@ -116,6 +119,3 @@ spec:
       tolerations:
 {{ toYaml .Values.tolerations | indent 8 }}
       {{- end }}
-      {{- if .Values.serviceAccount.create -}}
-      serviceAccountName: {{ template "cp-kafka-connect.serviceAccountName" . }}
-      {{- end -}}

--- a/charts/cp-kafka-connect/templates/serviceaccount.yaml
+++ b/charts/cp-kafka-connect/templates/serviceaccount.yaml
@@ -1,0 +1,11 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "cp-kafka-connect.serviceAccountName" . }}
+  labels:
+    app: {{ template "cp-kafka-connect.name" . }}
+    chart: {{ .Chart.Name }}-{{ .Chart.Version }}
+    heritage: {{ .Release.Service }}
+    release: {{ .Release.Name }}
+{{- end -}}

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -94,3 +94,10 @@ kafka:
 ## e.g. gnoble-panther-cp-schema-registry:8081
 cp-schema-registry:
   url: ""
+
+serviceAccount:
+  # Specifies whether a ServiceAccount should be created
+  create: false
+  # The name of the ServiceAccount to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name:

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -99,5 +99,5 @@ serviceAccount:
   # Specifies whether a ServiceAccount should be created
   create: false
   # The name of the ServiceAccount to use.
-  # If not set and create is true, a name is generated using the fullname template
+  # If not set and create is true, a name is generated using the template name
   name:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add `ServiceAccount` for cp-kafka-connect.

We are using a custom kafka`ConfigProvider` to retrieve the credentials via SSM to access and pull the data from Oracle using kafka-connect-jdbc. To give fine-grained permissions we need to bind an IAM role to the service account.

## How was this patch tested?

Tested using helm on AWS EKS
