### PR TITLE
overriding schema registry url need to include protocol with path

### DIFF
--- a/charts/cp-ksql-server/README.md
+++ b/charts/cp-ksql-server/README.md
@@ -39,7 +39,7 @@ helm install --name my-confluent cp-helm-charts
 ### Install with a existing cp-kafka and cp-schema-registry release
 
 ```console
-helm install --set cp-zookeeper.url="unhinged-robin-cp-zookeeper:2181",cp-schema-registry.url="lolling-chinchilla-cp-schema-registry:8081" cp-helm-charts/charts/cp-ksql-server
+helm install --set cp-zookeeper.url="unhinged-robin-cp-zookeeper:2181",cp-schema-registry.url="http://lolling-chinchilla-cp-schema-registry:8081" cp-helm-charts/charts/cp-ksql-server
 ```
 
 ### Installed Components

--- a/charts/cp-ksql-server/values.yaml
+++ b/charts/cp-ksql-server/values.yaml
@@ -86,7 +86,7 @@ ksql:
 kafka:
   bootstrapServers: ""
 
-## e.g. gnoble-panther-cp-schema-registry:8081
+## e.g. http://gnoble-panther-cp-schema-registry:8081
 cp-schema-registry:
   url: ""
 


### PR DESCRIPTION
overriding schema registry url need to include protocol with path

## What changes were proposed in this pull request?

documentation does not mention that the protocol is not added to url when adding schema registry url

## How was this patch tested?

tested on azure k8s cluster and minikube.
