### PR TITLE
Fix typo in resources section (cp-kafka README)

### DIFF
--- a/charts/cp-kafka/README.md
+++ b/charts/cp-kafka/README.md
@@ -154,8 +154,8 @@ The configuration parameters in this section control the resources requested and
 | --------- | ----------- | ------- |
 | `resources.requests.cpu` | The amount of CPU to request. | see [values.yaml](values.yaml) for details |
 | `resources.requests.memory` | The amount of memory to request. | see [values.yaml](values.yaml) for details |
-| `resources.requests.limit` | The upper limit CPU usage for a Kafka Pod. | see [values.yaml](values.yaml) for details |
-| `resources.requests.limit` | The upper limit memory usage for a Kafka Pod. | see [values.yaml](values.yaml) for details |
+| `resources.limits.cpu` | The upper limit CPU usage for a Kafka Pod. | see [values.yaml](values.yaml) for details |
+| `resources.limits.memory` | The upper limit memory usage for a Kafka Pod. | see [values.yaml](values.yaml) for details |
 
 ### Annotations
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixes the `Resources` section parameter.

## How was this patch tested?

Referred to `values.yaml` and made sure documentation is consistent with the keys.
