### PR TITLE
Change tolerations from map to array

### DIFF
--- a/charts/cp-control-center/values.yaml
+++ b/charts/cp-control-center/values.yaml
@@ -59,7 +59,7 @@ nodeSelector: {}
 
 ## Taints to tolerate on node assignment:
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-tolerations: {}
+tolerations: []
 
 ## Monitoring
 ## Kafka JMX Settings

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -61,7 +61,7 @@ nodeSelector: {}
 
 ## Taints to tolerate on node assignment:
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-tolerations: {}
+tolerations: []
 
 ## Monitoring
 ## Kafka Connect JMX Settings

--- a/charts/cp-kafka-rest/values.yaml
+++ b/charts/cp-kafka-rest/values.yaml
@@ -44,7 +44,7 @@ nodeSelector: {}
 
 ## Taints to tolerate on node assignment:
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-tolerations: {}
+tolerations: []
 
 ## Kafka REST configuration options
 ## ref: https://docs.confluent.io/current/kafka-rest/docs/config.html

--- a/charts/cp-kafka/values.yaml
+++ b/charts/cp-kafka/values.yaml
@@ -99,7 +99,7 @@ nodeSelector: {}
 
 ## Taints to tolerate on node assignment:
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-tolerations: {}
+tolerations: []
 
 ## Monitoring
 ## Kafka JMX Settings

--- a/charts/cp-ksql-server/values.yaml
+++ b/charts/cp-ksql-server/values.yaml
@@ -44,7 +44,7 @@ nodeSelector: {}
 
 ## Taints to tolerate on node assignment:
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-tolerations: {}
+tolerations: []
 
 ## Monitoring
 ## JMX Settings

--- a/charts/cp-schema-registry/values.yaml
+++ b/charts/cp-schema-registry/values.yaml
@@ -63,7 +63,7 @@ nodeSelector: {}
 
 ## Taints to tolerate on node assignment:
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-tolerations: {}
+tolerations: []
 
 ## Monitoring
 ## Schema Registry JMX Settings

--- a/charts/cp-zookeeper/values.yaml
+++ b/charts/cp-zookeeper/values.yaml
@@ -94,7 +94,7 @@ nodeSelector: {}
 
 ## Taints to tolerate on node assignment:
 ## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
-tolerations: {}
+tolerations: []
 
 ## Monitoring
 ## Zookeeper JMX Settings


### PR DESCRIPTION
## What changes were proposed in this pull request?

Changes the type of tolerations to prevent errors when configuring them. Currently, it is configured to be map; where it is, in fact, the array in the [PodSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.16/#podspec-v1-core).

It solves the following warnings:
```
2019/12/05 21:10:55 Warning: Merging destination map for chart 'cp-kafka'. Overwriting table item 'tolerations', with non table value: [map[effect:NoSchedule key:node-role.kubernetes.io/kafka operator:Exists]]
2019/12/05 21:10:55 Warning: Merging destination map for chart 'cp-zookeeper'. Overwriting table item 'tolerations', with non table value: [map[effect:NoSchedule key:node-role.kubernetes.io/kafka operator:Exists]]
2019/12/05 21:10:55 Warning: Merging destination map for chart 'cp-helm-charts'. Overwriting table item 'tolerations', with non table value: [map[effect:NoSchedule key:node-role.kubernetes.io/kafka operator:Exists]]
2019/12/05 21:10:55 Warning: Merging destination map for chart 'cp-helm-charts'. Overwriting table item 'tolerations', with non table value: [map[effect:NoSchedule key:node-role.kubernetes.io/kafka operator:Exists]]
2019/12/05 21:10:55 Warning: Merging destination map for chart 'cp-kafka'. Overwriting table item 'tolerations', with non table value: [map[effect:NoSchedule key:node-role.kubernetes.io/kafka operator:Exists]]
2019/12/05 21:10:55 Warning: Merging destination map for chart 'cp-zookeeper'. Overwriting table item 'tolerations', with non table value: [map[effect:NoSchedule key:node-role.kubernetes.io/kafka operator:Exists]]
```

## How was this patch tested?

Tested on local machine using `helm template` that both outputs are the same.
