### PR TITLE
[connect] add support to volumes & volume mounts

### DIFF
--- a/charts/cp-kafka-connect/README.md
+++ b/charts/cp-kafka-connect/README.md
@@ -125,6 +125,18 @@ The configuration parameters in this section control the resources requested and
 | `resources.requests.limit` | The upper limit CPU usage for a Kafka Connect Pod. | see [values.yaml](values.yaml) for details |
 | `resources.requests.limit` | The upper limit memory usage for a Kafka Connect Pod. | see [values.yaml](values.yaml) for details |
 
+### Volume Mounts
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `volumeMounts` | Volume mounts to configure for Kafka Connect containers | see [values.yaml](values.yaml) for details |
+
+### Volumes
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `volumes` | Volumes to configure for Kafka Connect containers | see [values.yaml](values.yaml) for details |
+
 ### Annotations
 
 | Parameter | Description | Default |

--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -69,6 +69,10 @@ spec:
             {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+          {{- if gt (len .Values.volumeMounts) 0 }}
+          volumeMounts:
+{{ toYaml .Values.volumeMounts | indent 10 }}
+          {{- end}}
           env:
             - name: CONNECT_REST_ADVERTISED_HOST_NAME
               valueFrom:
@@ -112,6 +116,9 @@ spec:
         configMap:
           name: {{ template "cp-kafka-connect.fullname" . }}-jmx-configmap
       {{- end }}
+      {{- if gt (len .Values.volumes) 0 }}
+{{ toYaml .Values.volumes | indent 6 }}
+      {{- end}}
       {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -52,6 +52,15 @@ resources: {}
   #  cpu: 100m
   #  memory: 128Mi
 
+volumeMounts: []
+#  - name: gcs
+#    mountPath: /usr/share/credentials
+
+volumes: []
+#  - name: gcs
+#    secret:
+#      secretName: connect-gcs
+
 ## Custom pod annotations
 podAnnotations: {}
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

This resolves #328 & resolves  #360 
Allows to mount secret volume (or other types) to a Kafka Connect container using values file.

## How was this patch tested?

helm install on gke using flux helm operator