### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Confluent Open Source Helm Chart
 
-**The Confluent Platform Helm charts are not supported by Confluent. If you want to use Helm charts in a test or production environment, follow these instructions to install [Confluent Operator](https://docs.confluent.io/current/installation/operator/index.html#operator-about-intro).**
+**Open Source Helm charts are not supported by Confluent. If you want to use Helm charts in a test or production environment, follow these instructions to install [Confluent Operator](https://docs.confluent.io/current/installation/operator/index.html#operator-about-intro).**
 
 The [Confluent Platform Helm charts](https://github.com/confluentinc/cp-helm-charts) enable you to deploy Confluent Platform services on Kubernetes for development, test, and proof of concept environments.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Confluent Open Source Helm Chart
 
-**Open Source Helm charts are not supported by Confluent. If you want to use Helm charts in a test or production environment, follow these instructions to install [Confluent Operator](https://docs.confluent.io/current/installation/operator/index.html#operator-about-intro).**
+**Open Source Helm charts are not supported by Confluent. If you want to use manage Confluent Platform on Kubernetes in a test or production environment, follow these instructions to install [Confluent Operator](https://docs.confluent.io/current/installation/operator/index.html#operator-about-intro).**
 
 The [Confluent Platform Helm charts](https://github.com/confluentinc/cp-helm-charts) enable you to deploy Confluent Platform services on Kubernetes for development, test, and proof of concept environments.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Confluent Open Source Helm Chart
 
-**Open Source Helm charts are not supported by Confluent. If you want to use manage Confluent Platform on Kubernetes in a test or production environment, follow these instructions to install [Confluent Operator](https://docs.confluent.io/current/installation/operator/index.html#operator-about-intro).**
+**Open Source Helm charts are not supported by Confluent. If you want to use Confluent Platform on Kubernetes in a test or production environment, follow these instructions to install [Confluent Operator](https://docs.confluent.io/current/installation/operator/index.html#operator-about-intro).**
 
 The [Confluent Platform Helm charts](https://github.com/confluentinc/cp-helm-charts) enable you to deploy Confluent Platform services on Kubernetes for development, test, and proof of concept environments.
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Confluent Open Source Helm Chart
 
-**The Confluent Platform Helm charts are in developer preview and are not supported for production use.**
+**The Confluent Platform Helm charts are not supported by Confluent. If you want to use Helm charts in a test or production environment, follow these instructions to install [Confluent Operator](https://docs.confluent.io/current/installation/operator/index.html#operator-about-intro).**
 
 The [Confluent Platform Helm charts](https://github.com/confluentinc/cp-helm-charts) enable you to deploy Confluent Platform services on Kubernetes for development, test, and proof of concept environments.
 


### PR DESCRIPTION
We want to discourage customers from getting started with open source Helm charts. They need to be using Confluent Operator.

## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. helm upgrade on minikube, helm install on gke)
