### PR TITLE
Fix cp-control-center resource block

### DIFF
--- a/charts/cp-control-center/templates/deployment.yaml
+++ b/charts/cp-control-center/templates/deployment.yaml
@@ -42,7 +42,7 @@ spec:
               containerPort: {{ .Values.serviceHttpPort}}
               protocol: TCP
           resources:
-{{- toYaml .Values.resources | indent 12 }}
+{{ toYaml .Values.resources | indent 12 }}
           env:
             - name: CONTROL_CENTER_BOOTSTRAP_SERVERS
               value: {{ template "cp-control-center.kafka.bootstrapServers" . }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Removed a dash which generate an error when we set resource (limit or request) in values.yaml over cp-control-center

This PR made the line similar to the one in the other chart of this repository, such as
https://github.com/confluentinc/cp-helm-charts/blob/2b67e7951206f4d8042de7fe5414f73eb06105ca/charts/cp-kafka/templates/statefulset.yaml#L76

## How was this patch tested?

This was tested on minikube.
