### PR TITLE
Make enterprise features optional

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Confluent Platform Community Edition
 name: cp-helm-charts
-version: 0.4.0
+version: 0.4.1

--- a/charts/cp-kafka/Chart.yaml
+++ b/charts/cp-kafka/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Confluent Kafka on Kubernetes
 name: cp-kafka
-version: 0.1.0
+version: 0.1.1

--- a/charts/cp-kafka/templates/statefulset.yaml
+++ b/charts/cp-kafka/templates/statefulset.yaml
@@ -121,10 +121,12 @@ spec:
           value: {{ include "cp-kafka.cp-zookeeper.service-name" . | quote }}
         - name: KAFKA_LOG_DIRS
           value: {{ include "cp-kafka.log.dirs" . | quote }}
+        {{- if .Values.enableEnterpriseFeatures }}
         - name: KAFKA_METRIC_REPORTERS
           value: "io.confluent.metrics.reporter.ConfluentMetricsReporter"
         - name: CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS
           value: {{ printf "PLAINTEXT://%s:9092" (include "cp-kafka.cp-kafka-headless.fullname" .) | quote }}
+        {{- end }}
         {{- range $key, $value := .Values.configurationOverrides }}
         - name: {{ printf "KAFKA_%s" $key | replace "." "_" | upper | quote }}
           value: {{ $value | quote }}

--- a/charts/cp-kafka/values.yaml
+++ b/charts/cp-kafka/values.yaml
@@ -128,6 +128,8 @@ nodeport:
   servicePort: 19092
   firstListenerPort: 31090
 
+enableEnterpriseFeatures: true
+
 ## ------------------------------------------------------
 ## Zookeeper
 ## ------------------------------------------------------

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
 - name: cp-kafka
-  version: 0.1.0
+  version: 0.1.1
   repository: file://./charts/cp-kafka
   condition: cp-kafka.enabled
 - name: cp-zookeeper


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a variable to cp-kafka/values.yaml to enable or disable enterprise
features. Currently this only means enabling or disabling the
ConfluentMetricsReporter and some configuration for it. Doing this
allows us to use open source Kafka docker image without changing
anything in the chart.

Fixes #377 

## How was this patch tested?

```
helm template --set cp-kafka.enableEnterpriseFeatures=false . > ~/tmp/kafka_enterprise_disabled.yaml
helm template --set cp-kafka.enableEnterpriseFeatures=true . > ~/tmp/kafka_enterprise_enabled.yaml
diff -u ~/tmp/kafka_enterprise_{enabled,disabled}.yaml
```

```
--- /home/oshe/tmp/kafka_enterprise_enabled.yaml	2020-01-22 12:52:39.654092569 +0100
+++ /home/oshe/tmp/kafka_enterprise_disabled.yaml	2020-01-22 12:52:47.542105356 +0100
@@ -912,10 +912,6 @@
           value: "RELEASE-NAME-cp-zookeeper-headless:2181"
         - name: KAFKA_LOG_DIRS
           value: "/opt/kafka/data-0/logs"
-        - name: KAFKA_METRIC_REPORTERS
-          value: "io.confluent.metrics.reporter.ConfluentMetricsReporter"
-        - name: CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS
-          value: "PLAINTEXT://RELEASE-NAME-cp-kafka-headless:9092"
         - name: "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP"
           value: "PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT"
         - name: "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR"

```
