### PR TITLE
Use headless service name from _helpers.tpl variable cp-kafka.cp-kafka-headless.fullname

### DIFF
--- a/charts/cp-kafka/templates/NOTES.txt
+++ b/charts/cp-kafka/templates/NOTES.txt
@@ -37,4 +37,4 @@ To connect from a client pod:
   echo "$MESSAGE" | kafka-console-producer --broker-list {{ template "cp-kafka.fullname" . }}:9092 --topic {{ template "cp-kafka.fullname" . }}-topic && \
 
   # Consume a test message from the topic
-  kafka-console-consumer --bootstrap-server {{ template "cp-kafka.fullname" . }}-headless:9092 --topic {{ template "cp-kafka.fullname" . }}-topic --from-beginning --timeout-ms 2000 | grep "$MESSAGE"
+  kafka-console-consumer --bootstrap-server {{ template "cp-kafka.cp-kafka-headless.fullname" . }}:9092 --topic {{ template "cp-kafka.fullname" . }}-topic --from-beginning --timeout-ms 2000 | grep "$MESSAGE"

--- a/charts/cp-kafka/templates/headless-service.yaml
+++ b/charts/cp-kafka/templates/headless-service.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "cp-kafka.fullname" . }}-headless
+  name: {{ template "cp-kafka.cp-kafka-headless.fullname" . }}
   labels:
     app: {{ template "cp-kafka.name" . }}
     chart: {{ template "cp-kafka.chart" . }}

--- a/charts/cp-kafka/templates/statefulset.yaml
+++ b/charts/cp-kafka/templates/statefulset.yaml
@@ -18,7 +18,7 @@ spec:
       app: {{ template "cp-kafka.name" . }}
       release: {{ .Release.Name }}
   {{- end }}
-  serviceName: {{ template "cp-kafka.fullname" . }}-headless
+  serviceName: {{ template "cp-kafka.cp-kafka-headless.fullname" . }}
   podManagementPolicy: {{ .Values.podManagementPolicy }}
   replicas: {{ default 3 .Values.brokers }}
   updateStrategy:
@@ -146,7 +146,7 @@ spec:
         - -exc
         - |
           export KAFKA_BROKER_ID=${HOSTNAME##*-} && \
-          export KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://${POD_NAME}.{{ template "cp-kafka.fullname" . }}-headless.${POD_NAMESPACE}:9092{{ include "cp-kafka.configuration.advertised.listeners" . }} && \
+          export KAFKA_ADVERTISED_LISTENERS=PLAINTEXT://${POD_NAME}.{{ template "cp-kafka.cp-kafka-headless.fullname" . }}.${POD_NAMESPACE}:9092{{ include "cp-kafka.configuration.advertised.listeners" . }} && \
           exec /etc/confluent/docker/run
         volumeMounts:
         {{- if .Values.persistence.enabled }}

--- a/charts/cp-kafka/templates/tests/canary-pod.yaml
+++ b/charts/cp-kafka/templates/tests/canary-pod.yaml
@@ -23,5 +23,5 @@ spec:
       # Produce a test message to the topic
       echo "$MESSAGE" | kafka-console-producer --broker-list {{ template "cp-kafka.fullname" . }}:9092 --topic {{ template "cp-kafka.fullname" . }}-canary-topic && \
       # Consume a test message from the topic
-      kafka-console-consumer --bootstrap-server {{ template "cp-kafka.fullname" . }}-headless:9092 --topic {{ template "cp-kafka.fullname" . }}-canary-topic --from-beginning --timeout-ms 2000 | grep "$MESSAGE"
+      kafka-console-consumer --bootstrap-server {{ template "cp-kafka.cp-kafka-headless.fullname" . }}:9092 --topic {{ template "cp-kafka.fullname" . }}-canary-topic --from-beginning --timeout-ms 2000 | grep "$MESSAGE"
   restartPolicy: Never


### PR DESCRIPTION
## What changes were proposed in this pull request?

Name of the headless service is using the variable from _helpers.tpl (cp-kafka.cp-kafka-headless.fullname) and not {{ template "cp-kafka.fullname" . }}-headless. This way the headless service has the same name everywhere. 

## How was this patch tested?

Ran on local K8s cluster
