### PR TITLE
Increase Schema Registry Heap

### DIFF
--- a/charts/cp-schema-registry/values.yaml
+++ b/charts/cp-schema-registry/values.yaml
@@ -34,7 +34,7 @@ customEnv: {}
 servicePort: 8081
 
 ## Schema registry JVM Heap Option
-heapOptions: "-Xms512M -Xmx512M"
+heapOptions: "-Xms1000M -Xmx1000M"
 
 ## You can list load balanced service endpoint, or list of all brokers (which is hard in K8s).  e.g.:
 ## bootstrapServers: "PLAINTEXT://dozing-prawn-kafka-headless:9092"


### PR DESCRIPTION
512M doens't seem to be sufficient for v5.4.0

## What changes were proposed in this pull request?

Increase to the default heap specified in the values.yaml

## How was this patch tested?

This issue was discovered in a live environment on AKS 1.13.x upon upgrade from the 5.3.1 Schema Registry release. The service would fail to start due to insufficient heap. Further testing showed 1000M to be a reasonable floor for the heap size that would allow the service. This was tested and verified across 2 additional environments, also on AKS.
