### PR TITLE
cp-kafka-connect: Support creating secrets and volumes

### DIFF
--- a/charts/cp-kafka-connect/README.md
+++ b/charts/cp-kafka-connect/README.md
@@ -110,6 +110,13 @@ The configuration parameters in this section control the resources requested and
 | `configurationOverrides` | Kafka Connect [configuration](https://docs.confluent.io/current/connect/references/allconfigs.html) overrides in the dictionary format. | `{}` |
 | `customEnv` | Custom environmental variables | `{}` |
 
+### Volumes
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `volumes` | Volumes for connect-server container | see [values.yaml](values.yaml) for details |
+| `volumeMounts` | Volume mounts for connect-server container | see [values.yaml](values.yaml) for details |
+
 ### Kafka Connect JVM Heap Options
 
 | Parameter | Description | Default |

--- a/charts/cp-kafka-connect/README.md
+++ b/charts/cp-kafka-connect/README.md
@@ -117,6 +117,12 @@ The configuration parameters in this section control the resources requested and
 | `volumes` | Volumes for connect-server container | see [values.yaml](values.yaml) for details |
 | `volumeMounts` | Volume mounts for connect-server container | see [values.yaml](values.yaml) for details |
 
+### Secrets
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `secrets` | Secret with one or more `key:value` pairs | see [values.yaml](values.yaml) for details |
+
 ### Kafka Connect JVM Heap Options
 
 | Parameter | Description | Default |

--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -102,11 +102,18 @@ spec:
             - name: KAFKA_JMX_PORT
               value: "{{ .Values.jmx.port }}"
             {{- end }}
+          {{- if .Values.volumeMounts }}
+          volumeMounts:
+{{ toYaml .Values.volumeMounts | indent 10 }}
+          {{- end}}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
       {{- end }}
       volumes:
+      {{- if .Values.volumes }}
+{{ toYaml .Values.volumes | trim | indent 6 }}
+      {{- end}}
       {{- if .Values.prometheus.jmx.enabled }}
       - name: jmx-config
         configMap:

--- a/charts/cp-kafka-connect/templates/secrets.yaml
+++ b/charts/cp-kafka-connect/templates/secrets.yaml
@@ -1,0 +1,16 @@
+{{- if .Values.secrets }}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ template "cp-kafka-connect.fullname" . }}
+  labels:
+    app: {{ template "cp-kafka-connect.name" . }}
+    chart: {{ template "cp-kafka-connect.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+type: Opaque
+data:
+  {{- range $key, $value := .Values.secrets }}
+  {{ $key }}: {{ $value | b64enc }}
+  {{- end }}
+{{- end }}

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -94,3 +94,16 @@ kafka:
 ## e.g. gnoble-panther-cp-schema-registry:8081
 cp-schema-registry:
   url: ""
+
+## List of volumeMounts for connect server container
+## ref: https://kubernetes.io/docs/concepts/storage/volumes/
+volumeMounts:
+# - name: credentials
+#   mountPath: /etc/creds-volume
+
+## List of volumeMounts for connect server container
+## ref: https://kubernetes.io/docs/concepts/storage/volumes/
+volumes:
+# - name: credentials
+#   secret:
+#     secretName: creds

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -107,3 +107,10 @@ volumes:
 # - name: credentials
 #   secret:
 #     secretName: creds
+
+## Secret with multiple keys to serve the purpose of multiple secrets
+## Values for all the keys will be base64 encoded when the Secret is created or updated
+## ref: https://kubernetes.io/docs/concepts/configuration/secret/
+secrets:
+  # username: kafka123
+  # password: connect321


### PR DESCRIPTION
## What changes were proposed in this pull request?

* This PR allows creating Kubernetes secret and mounting volumes
* This will do the following:
    * resolve #328 as volumes can be created and secrets can be mounted too
    * resolve #360 as secret can be created with multiple `key:value` pairs
* There is already a similar PR  ( #361 ). This one, however, covers everything in #361 and on top of which it gives an option to create secret as well. With this being merged, it safely closes #361 
* Explanatory comments have been added in the values file for the newly introduced values

## How was this patch tested?
* Helm (v2.16.1) was used to deploy this patch on GKE (1.14.10-gke.17)
* `kubectl exec` command was used to make sure the secrets and volumes are being created and mounted successfully
* It was made sure that the values of all the secrets keys are base64 encoded first while creating the secret