### PR TITLE
Add support to run custom scripts

### DIFF
--- a/charts/cp-kafka-connect/README.md
+++ b/charts/cp-kafka-connect/README.md
@@ -161,6 +161,13 @@ The configuration parameters in this section control the resources requested and
 | `prometheus.jmx.port` | JMX Exporter Port which exposes metrics in Prometheus format for scraping. | `5556` |
 | `prometheus.jmx.resources` | JMX Exporter resources configuration. | see [values.yaml](values.yaml) for details |
 
+### Running Custom Scripts
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `customEnv.CUSTOM_SCRIPT_PATH` | Path to external bash script to run inside the container | see [values.yaml](values.yaml) for details |
+| `livenessProbe` | Requirement of `livenessProbe` depends on the custom script to be run  | see [values.yaml](values.yaml) for details |
+
 ### Deployment Topology
 
 | Parameter | Description | Default |

--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -102,6 +102,19 @@ spec:
             - name: KAFKA_JMX_PORT
               value: "{{ .Values.jmx.port }}"
             {{- end }}
+        {{- if .Values.customEnv.CUSTOM_SCRIPT_PATH }}
+          command:
+            - /bin/bash
+            - -c
+            - |
+              /etc/confluent/docker/run &
+              $CUSTOM_SCRIPT_PATH
+              sleep infinity
+          {{- if .Values.livenessProbe }}
+          livenessProbe:
+{{ toYaml .Values.livenessProbe | trim | indent 12 }}
+          {{- end }}
+        {{- end }}
           {{- if .Values.volumeMounts }}
           volumeMounts:
 {{ toYaml .Values.volumeMounts | indent 10 }}

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -38,7 +38,9 @@ configurationOverrides:
 heapOptions: "-Xms512M -Xmx512M"
 
 ## Additional env variables
+## CUSTOM_SCRIPT_PATH is the path of the custom shell script to be ran mounted in a volume
 customEnv: {}
+  # CUSTOM_SCRIPT_PATH: /etc/scripts/create-connectors.sh
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
@@ -114,3 +116,16 @@ volumes:
 secrets:
   # username: kafka123
   # password: connect321
+
+## These values are used only when "customEnv.CUSTOM_SCRIPT_PATH" is defined.
+## "livenessProbe" is required only for the edge cases where the custom script to be ran takes too much time
+## and errors by the ENTRYPOINT are ignored by the container
+## As an example such a similar script is added to "cp-helm-charts/examples/create-connectors.sh"
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+livenessProbe:
+  # httpGet:
+  #   path: /connectors
+  #   port: 8083
+  # initialDelaySeconds: 30
+  # periodSeconds: 5
+  # failureThreshold: 10

--- a/examples/create-connectors.sh
+++ b/examples/create-connectors.sh
@@ -1,0 +1,31 @@
+## A script similar to this can be used to create connectors making sure the endpoints are ready
+
+echo "Waiting for Kafka Connect to start listening on kafka-connect  "
+while :; do
+    # Check if the connector endpoint is ready
+    # If not check again
+    curl_status=$(curl -s -o /dev/null -w %{http_code} http://localhost:{{ .Values.servicePort }}/connectors)
+    echo -e $(date) "Kafka Connect listener HTTP state: " $curl_status " (waiting for 200)"
+    if [ $curl_status -eq 200 ]; then
+        break
+    fi
+    sleep 5
+done
+
+echo "======> Creating connectors"
+# Send a simple POST request to create the connector
+curl -X POST \
+    -H "Content-Type: application/json" \
+    --data '{
+    "name": "sample-connector",
+    "config": {
+        "connector.class": "io.confluent.connect.jdbc.JdbcSourceConnector",
+        "tasks.max": 1,
+        "connection.url": "jdbc:mysql://123.4.5.67:3306/test_db?user=root&password=pass",
+        "mode": "incrementing",
+        "incrementing.column.name": "id",
+        "timestamp.column.name": "modified",
+        "topic.prefix": "sample-connector-",
+        "poll.interval.ms": 1000
+        }
+    }' http://$CONNECT_REST_ADVERTISED_HOST_NAME:8083/connectors


### PR DESCRIPTION
## What changes were proposed in this pull request?

* Added a way to run custom shell scripts.
* Resolves #390 
* Conditional `livenessProbe` has also been added in case the custom script interrupts in the detection of the pod failure.
* **_For example:_** 
    A shell script that checks for the connector endpoint to be ready first "infinitely" and once available sends POST requests to create connectors. Scripts like these can take a long time as the connector container tries to the Kafka-broker endpoint. load config etc. In case Kafka-brokers (i.e. "kafka.bootstrapServers") are unavailable, pod should restart but now it would not because their is a script running infinitely or for a long time producing informational messages until the endpoint is ready.
    To avoid such conditions, `livenessProbe` comes to rescue which starts the container if the connect endpoint is not ready for a specified period of time and `livenessProbe` fails
* A sample script has been provided in "cp-helm-charts/examples/create-connectors.sh" which can be really useful to the users who would like to automate the step of creating the connectors.

## How is this PR useful?
* Users will be able to write simple bash scripts and run them while deploying in order to perform various tasks like **_creating connectors_**
* A script like below can be a good example:

    ```shell
    echo "Waiting for Kafka Connect to start listening on kafka-connect  "
    while :; do
        # Check if the connector endpoint is ready
        # If not check again
        curl_status=$(curl -s -o /dev/null -w %{http_code} http://localhost:{{ .Values.servicePort }}/connectors)
        echo -e $(date) "Kafka Connect listener HTTP state: " $curl_status " (waiting for 200)"
        if [ $curl_status -eq 200 ]; then
            break
        fi
        sleep 5
    done

    echo "======> Creating connectors"
    # Send a simple POST request to create the connector
    curl -X POST \
        -H "Content-Type: application/json" \
        --data '{
        "name": "sample-connector",
        "config": {
            "connector.class": "io.confluent.connect.jdbc.JdbcSourceConnector",
            "tasks.max": 1,
            "connection.url": "jdbc:mysql://123.4.5.67:3306/test_db?user=root&password=pass",
            "mode": "incrementing",
            "incrementing.column.name": "id",
            "timestamp.column.name": "modified",
            "topic.prefix": "sample-connector-",
            "poll.interval.ms": 1000
            }
        }' http://$CONNECT_REST_ADVERTISED_HOST_NAME:8083/connectors

    ```
* This bash script is inspired by [this comment](https://github.com/confluentinc/cp-docker-images/issues/467#issuecomment-461104319) on one of the [confluentinc/cp-docker-images](https://github.com/confluentinc/cp-docker-images) issues.
## How was this patch tested?

* `helm install` and `helm upgrade` were used to deploy and upgrade this patch on GKE (1.14.10-gke.17)
* `kubectl logs` command was used to make sure that the custom is running successfully
