### PR TITLE
Expose the headless kafka service to allow CLI

### DIFF
--- a/charts/cp-kafka/templates/headless-service.yaml
+++ b/charts/cp-kafka/templates/headless-service.yaml
@@ -11,7 +11,6 @@ spec:
   ports:
     - port: 9092
       name: broker
-  clusterIP: None
   selector:
     app: {{ template "cp-kafka.name" . }}
     release: {{ .Release.Name }}


### PR DESCRIPTION

## What changes were proposed in this pull request?

The Kafka CLI tools are very useful for debugging, but also for
administrating a Kafka cluster. Unfortunately, the Helm chart currently
installs Kafka in such a way that the charts don't work. This is because for
some operations it needs the headless service to be accessible. This commit
removes the hardcoded non-exposure of the headless service to allow the CLI
to work as designed

## How was this patch tested?

Helm install on Azure Kubernetes Service
