### PR TITLE
[cp-zookeeper] - Add Custom env parameter at helm charts

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Confluent Platform Community Edition
 name: cp-helm-charts
-version: 0.4.1
+version: 0.4.2

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Confluent Platform Community Edition
 name: cp-helm-charts
-version: 0.4.2
+version: 0.4.1

--- a/charts/cp-zookeeper/templates/statefulset.yaml
+++ b/charts/cp-zookeeper/templates/statefulset.yaml
@@ -123,9 +123,13 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        {{- range $key, $value := .Values.configurationOverrides }}
+        - name: {{ printf "ZOOKEEPER_%s" $key | replace "." "_" | upper | quote }}
+          value: {{ $value | quote }}
+        {{- end }}
         {{- range $key, $value := .Values.customEnv }}
         - name: {{ $key | quote }}
-          value: {{ $value | quote }}
+          value: {{ $value | quote }}              
         {{- end }}
         command:
         - "bash"

--- a/charts/cp-zookeeper/templates/statefulset.yaml
+++ b/charts/cp-zookeeper/templates/statefulset.yaml
@@ -123,6 +123,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        {{- range $key, $value := .Values.customEnv }}
+        - name: {{ $key | quote }}
+          value: {{ $value | quote }}
+        {{- end }}
         command:
         - "bash"
         - "-c"

--- a/charts/cp-zookeeper/values.yaml
+++ b/charts/cp-zookeeper/values.yaml
@@ -48,6 +48,11 @@ autoPurgePurgeInterval: 24
 ## Zookeeper JVM Heap Option
 heapOptions: "-Xms512M -Xmx512M"
 
+## Additional env variables
+customEnv: {}
+  # ZOOKEEPER_LOG4J_ROOT_LOGLEVEL: "WARN"
+  # ZOOKEEPER_TOOLS_LOG4J_LOGLEVEL: "ERROR"
+
 ## Port
 ## ref: https://zookeeper.apache.org/doc/r3.4.10/zookeeperAdmin.html#sc_configuration
 serverPort: 2888

--- a/charts/cp-zookeeper/values.yaml
+++ b/charts/cp-zookeeper/values.yaml
@@ -48,10 +48,15 @@ autoPurgePurgeInterval: 24
 ## Zookeeper JVM Heap Option
 heapOptions: "-Xms512M -Xmx512M"
 
+## Zookeeper Server properties
+## ref: https://zookeeper.apache.org/doc/r3.3.2/zookeeperAdmin.html#sc_configuration
+configurationOverrides: {}
+  # "log4j.root.loglevel: WARN"
+  # "tools.log4j.loglevel: ERROR"
+
 ## Additional env variables
 customEnv: {}
-  # ZOOKEEPER_LOG4J_ROOT_LOGLEVEL: "WARN"
-  # ZOOKEEPER_TOOLS_LOG4J_LOGLEVEL: "ERROR"
+
 
 ## Port
 ## ref: https://zookeeper.apache.org/doc/r3.4.10/zookeeperAdmin.html#sc_configuration


### PR DESCRIPTION
## What changes were proposed in this pull request?

Propose to add customEnvs in cp-zookeeper helm/charts. For example change log level and others envs.

## How was this patch tested?

This patch are tested in Kubernetes EKS env.