### PR TITLE
Fix kafka-rest jmx connection

### DIFF
--- a/charts/cp-kafka-rest/templates/deployment.yaml
+++ b/charts/cp-kafka-rest/templates/deployment.yaml
@@ -85,7 +85,7 @@ spec:
             value: {{ $value | quote }}
           {{- end }}
           {{- if .Values.jmx.port }}
-          - name: KAFKA_REST_JMX_PORT
+          - name: KAFKAREST_JMX_PORT
             value: "{{ .Values.jmx.port }}"
           {{- end }}
       {{- if .Values.imagePullSecrets }}


### PR DESCRIPTION
This fixes the connection issue between the prometheus jmx exporter and kafka-rest described [here](https://github.com/confluentinc/cp-helm-charts/issues/277). 

The correct environment variables can be seen in [here](https://github.com/confluentinc/cp-docker-images/blob/c34affec0d267e0ef730b6ce31939401e134bd4f/debian/kafka-rest/include/etc/confluent/docker/launch#L31)

## What changes were proposed in this pull request?

Change the environment variable name setting the JMX connection port for kafka rest

## How was this patch tested?
This solution was tested by pulling the chart locally, modifying the environment variable and installing the chart from the local chart.
