### PR TITLE
Fix targetPort for external access via NodePort

### DIFF
--- a/charts/cp-kafka/templates/nodeport-service.yaml
+++ b/charts/cp-kafka/templates/nodeport-service.yaml
@@ -22,7 +22,7 @@ spec:
   ports:
     - name: external-broker
       port: {{ $servicePort }}
-      targetPort: {{ $externalListenerPort }}
+      targetPort: {{ $servicePort }}
       nodePort: {{ $externalListenerPort }}
       protocol: TCP
   selector:


### PR DESCRIPTION
## What changes were proposed in this pull request?

When setting `nodeport: true`, Kafka was not reachable externally using NodePort 31090..31092.

The `targetPort` was being incorrectly set to the same as value as `nodePort`:

```yaml
spec:
  type: NodePort
  ports:
    - name: external-broker
      port: 19092
      targetPort: 31090
      nodePort: 31090
      protocol: TCP
```

It should be the same as our `port` setting:

```yaml
spec:
  type: NodePort
  ports:
    - name: external-broker
      port: 19092
      targetPort: 19092
      nodePort: 31090
      protocol: TCP
```

## How was this patch tested?

helm install on rancher kubernetes, fixed the issue, kafka is accessible externally on the NodePorts 31090..31092.