### PR TITLE
Add Kafka Bootstrap env variable

### DIFF
--- a/charts/cp-kafka-rest/README.md
+++ b/charts/cp-kafka-rest/README.md
@@ -179,6 +179,12 @@ The configuration parameters in this section control the resources requested and
 | `cp-zookeeper.url` | Service name of Zookeeper cluster (Not needed if this is installed along with cp-kafka chart). | `""` |
 | `cp-zookeeper.clientPort` | Port of Zookeeper Cluster | `2181` |
 
+### Kafka Bootstrap
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `cp-kafka.url` | Url to connect to Kafka Bootstrap servers (Not needed if this is installed along with cp-kafka chart). | `""` |
+
 ### Schema Registry (optional)
 
 | Parameter | Description | Default |

--- a/charts/cp-kafka-rest/templates/deployment.yaml
+++ b/charts/cp-kafka-rest/templates/deployment.yaml
@@ -74,8 +74,13 @@ spec:
             valueFrom:
               fieldRef:
                 fieldPath: status.podIP
+          {{- if index .Values "cp-kafka" "url" }}
+          - name: KAFKA_REST_BOOTSTRAP_SERVERS
+            value: {{ index .Values "cp-kafka" "url" }}
+          {{- else }}
           - name: KAFKA_REST_ZOOKEEPER_CONNECT
             value: {{ template "cp-kafka-rest.cp-zookeeper.service-name" . }}
+          {{- end }}
           - name: KAFKA_REST_SCHEMA_REGISTRY_URL
             value: {{ template "cp-kafka-rest.cp-schema-registry.service-name" . }}
           - name: KAFKAREST_HEAP_OPTS

--- a/charts/cp-kafka-rest/values.yaml
+++ b/charts/cp-kafka-rest/values.yaml
@@ -86,6 +86,11 @@ external:
 cp-zookeeper:
   url: ""
 
+## If the Kafka Chart is disabled a URL of the kafka bootstrap server are required to connect
+## e.g. PLAINTEXT://ungaged-sparrow-cp-kafka-bootstrap:9092
+cp-kafka:
+  url: ""
+
 ## If the Kafka Chart is disabled a URL and port are required to connect
 ## e.g. gnoble-panther-cp-schema-registry:8081
 cp-schema-registry:


### PR DESCRIPTION
## What changes were proposed in this pull request?

I propose to include the KAFKA_REST_BOOTSTRAP_SERVERS environment variable since the docker image can connect to kafka with this variable too. [Reference](https://github.com/confluentinc/cp-docker-images/blob/5.3.1-post/debian/kafka-rest/include/etc/confluent/docker/configure#L19
)
## How was this patch tested?

Helm template to check the correct config of the chart and helm upgrade in a development k8s cluster of my company.

