### PR TITLE
add configuration override to zookeeper

### DIFF
--- a/charts/cp-zookeeper/templates/statefulset.yaml
+++ b/charts/cp-zookeeper/templates/statefulset.yaml
@@ -123,6 +123,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        {{- range $key, $value := .Values.configurationOverrides }}
+        - name: {{ printf "ZOOKEEPER_%s" $key | replace "." "_" | upper | quote }}
+          value: {{ $value | quote }}
+        {{- end }}
         command:
         - "bash"
         - "-c"


### PR DESCRIPTION

## What changes were proposed in this pull request?

Make it possible to override configuration on zookeeper, same way it is in kafka's statefulset.yaml


## How was this patch tested?

add to values.yaml:

  configurationOverrides:
    log4j.loggers: "org.apache.zookeeper=WARN"

and deploy helm as usual. You can then verify the new setting has been picked up:

kubectl logs deployment_name-cp-zookeeper-0  | grep LOG4J         
ZOOKEEPER_LOG4J_LOGGERS=org.apache.zookeeper=WARN
