### PR TITLE
Update latest to 5.5.0 Images

### DIFF
--- a/charts/cp-control-center/values.yaml
+++ b/charts/cp-control-center/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 ## Image Info
 ## ref: https://hub.docker.com/r/confluentinc/cp-kafka/
 image: confluentinc/cp-enterprise-control-center
-imageTag: 5.4.1
+imageTag: 5.5.0
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/charts/cp-kafka-connect/README.md
+++ b/charts/cp-kafka-connect/README.md
@@ -93,7 +93,7 @@ The configuration parameters in this section control the resources requested and
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `image` | Docker Image of Confluent Kafka Connect. | `confluentinc/cp-kafka-connect` |
-| `imageTag` | Docker Image Tag of Confluent Kafka Connect. | `5.4.1` |
+| `imageTag` | Docker Image Tag of Confluent Kafka Connect. | `5.5.0` |
 | `imagePullPolicy` | Docker Image Tag of Confluent Kafka Connect. | `IfNotPresent` |
 | `imagePullSecrets` | Secrets to be used for private registries. | see [values.yaml](values.yaml) for details |
 

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 ## Image Info
 ## ref: https://hub.docker.com/r/confluentinc/cp-kafka/
 image: confluentinc/cp-kafka-connect
-imageTag: 5.4.1
+imageTag: 5.5.0
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/charts/cp-kafka-rest/README.md
+++ b/charts/cp-kafka-rest/README.md
@@ -98,7 +98,7 @@ The configuration parameters in this section control the resources requested and
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `image` | Docker Image of Confluent REST Proxy. | `confluentinc/cp-kafka-rest` |
-| `imageTag` | Docker Image Tag of Confluent REST Proxy. | `5.4.1` |
+| `imageTag` | Docker Image Tag of Confluent REST Proxy. | `5.5.0` |
 | `imagePullPolicy` | Docker Image Tag of Confluent REST Proxy. | `IfNotPresent` |
 | `imagePullSecrets` | Secrets to be used for private registries. | see [values.yaml](values.yaml) for details |
 

--- a/charts/cp-kafka-rest/values.yaml
+++ b/charts/cp-kafka-rest/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 ## Image Info
 ## ref: https://hub.docker.com/r/confluentinc/cp-kafka/
 image: confluentinc/cp-kafka-rest
-imageTag: 5.4.1
+imageTag: 5.5.0
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/charts/cp-kafka/README.md
+++ b/charts/cp-kafka/README.md
@@ -115,7 +115,7 @@ The configuration parameters in this section control the resources requested and
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `image` | Docker Image of Confluent Kafka. | `confluentinc/cp-enterprise-kafka` |
-| `imageTag` | Docker Image Tag of Confluent Kafka. | `5.4.1` |
+| `imageTag` | Docker Image Tag of Confluent Kafka. | `5.5.0` |
 | `imagePullPolicy` | Docker Image Tag of Confluent Kafka. | `IfNotPresent` |
 | `imagePullSecrets` | Secrets to be used for private registries. | see [values.yaml](values.yaml) for details |
 

--- a/charts/cp-kafka/values.yaml
+++ b/charts/cp-kafka/values.yaml
@@ -12,7 +12,7 @@ brokers: 3
 ## Image Info
 ## ref: https://hub.docker.com/r/confluentinc/cp-kafka/
 image: confluentinc/cp-enterprise-kafka
-imageTag: 5.4.1
+imageTag: 5.5.0
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/charts/cp-ksql-server/README.md
+++ b/charts/cp-ksql-server/README.md
@@ -108,7 +108,7 @@ The configuration parameters in this section control the resources requested and
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `image` | Docker Image of Confluent KSQL Server. | `confluentinc/cp-ksql-server` |
-| `imageTag` | Docker Image Tag of Confluent KSQL Server. | `5.4.1` |
+| `imageTag` | Docker Image Tag of Confluent KSQL Server. | `5.5.0` |
 | `imagePullPolicy` | Docker Image Tag of Confluent KSQL Server. | `IfNotPresent` |
 | `imagePullSecrets` | Secrets to be used for private registries. | see [values.yaml](values.yaml) for details |
 

--- a/charts/cp-ksql-server/values.yaml
+++ b/charts/cp-ksql-server/values.yaml
@@ -6,7 +6,7 @@ replicaCount: 1
 
 ## Image Info
 ## ref: https://hub.docker.com/r/confluentinc/cp-ksql-server/
-image: confluentinc/cp-ksql-server
+image: confluentinc/cp-ksqldb-server
 imageTag: 5.5.0
 
 ## Specify a imagePullPolicy

--- a/charts/cp-ksql-server/values.yaml
+++ b/charts/cp-ksql-server/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 ## Image Info
 ## ref: https://hub.docker.com/r/confluentinc/cp-ksql-server/
 image: confluentinc/cp-ksql-server
-imageTag: 5.4.1
+imageTag: 5.5.0
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/charts/cp-schema-registry/README.md
+++ b/charts/cp-schema-registry/README.md
@@ -95,7 +95,7 @@ The configuration parameters in this section control the resources requested and
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `image` | Docker Image of Confluent Schema Registry. | `confluentinc/cp-schema-registry` |
-| `imageTag` | Docker Image Tag of Confluent Schema Registry. | `5.4.1` |
+| `imageTag` | Docker Image Tag of Confluent Schema Registry. | `5.5.0` |
 | `imagePullPolicy` | Docker Image Tag of Confluent Schema Registry. | `IfNotPresent` |
 | `imagePullSecrets` | Secrets to be used for private registries. | see [values.yaml](values.yaml) for details |
 

--- a/charts/cp-schema-registry/values.yaml
+++ b/charts/cp-schema-registry/values.yaml
@@ -12,7 +12,7 @@ replicaCount: 1
 ## Image Info
 ## ref: https://hub.docker.com/r/confluentinc/cp-schema-registry/
 image: confluentinc/cp-schema-registry
-imageTag: 5.4.1
+imageTag: 5.5.0
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/charts/cp-zookeeper/README.md
+++ b/charts/cp-zookeeper/README.md
@@ -109,7 +109,7 @@ The configuration parameters in this section control the resources requested and
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `image` | Docker Image of Confluent Zookeeper. | `confluentinc/cp-zookeeper` |
-| `imageTag` | Docker Image Tag of Confluent Zookeeper. | `5.4.1` |
+| `imageTag` | Docker Image Tag of Confluent Zookeeper. | `5.5.0` |
 | `imagePullPolicy` | Docker Image Tag of Confluent Zookeeper. | `IfNotPresent` |
 | `imagePullSecrets` | Secrets to be used for private registries. | see [values.yaml](values.yaml) for details |
 

--- a/charts/cp-zookeeper/values.yaml
+++ b/charts/cp-zookeeper/values.yaml
@@ -15,7 +15,7 @@ servers: 3
 ## Images Info
 ## ref: https://hub.docker.com/r/confluentinc/cp-zookeeper/
 image: confluentinc/cp-zookeeper
-imageTag: 5.4.1
+imageTag: 5.5.0
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images

--- a/examples/avro-client.yaml
+++ b/examples/avro-client.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
   - name: avro-client
-    image: confluentinc/cp-schema-registry:5.4.1
+    image: confluentinc/cp-schema-registry:5.5.0
     command:
       - sh
       - -c

--- a/examples/kafka-client.yaml
+++ b/examples/kafka-client.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
   - name: kafka-client
-    image: confluentinc/cp-kafka:5.4.1
+    image: confluentinc/cp-kafka:5.5.0
     command:
       - sh
       - -c

--- a/examples/ksql-demo.yaml
+++ b/examples/ksql-demo.yaml
@@ -23,19 +23,19 @@ metadata:
 spec:
   containers:
   - name: ksql-datagen-pageviews
-    image: confluentinc/ksql-examples:5.5.0
+    image: confluentinc/ksqldb-examples:5.5.0
     command:
       - sh
       - -c
       - "exec ksql-datagen quickstart=pageviews format=delimited topic=pageviews bootstrap-server=my-confluent-oss-cp-kafka:9092"
   - name: ksql-datagen-users
-    image: confluentinc/ksql-examples:5.5.0
+    image: confluentinc/ksqldb-examples:5.5.0
     command:
       - sh
       - -c
       - "ksql-datagen quickstart=users format=json topic=users iterations=1000 bootstrap-server=my-confluent-oss-cp-kafka:9092"
   - name: ksql
-    image: confluentinc/cp-ksql-cli:5.5.0
+    image: confluentinc/cp-ksqldb-cli:5.5.0
     command:
       - sh
       - -c

--- a/examples/ksql-demo.yaml
+++ b/examples/ksql-demo.yaml
@@ -23,19 +23,19 @@ metadata:
 spec:
   containers:
   - name: ksql-datagen-pageviews
-    image: confluentinc/ksql-examples:5.4.1
+    image: confluentinc/ksql-examples:5.5.0
     command:
       - sh
       - -c
       - "exec ksql-datagen quickstart=pageviews format=delimited topic=pageviews bootstrap-server=my-confluent-oss-cp-kafka:9092"
   - name: ksql-datagen-users
-    image: confluentinc/ksql-examples:5.4.1
+    image: confluentinc/ksql-examples:5.5.0
     command:
       - sh
       - -c
       - "ksql-datagen quickstart=users format=json topic=users iterations=1000 bootstrap-server=my-confluent-oss-cp-kafka:9092"
   - name: ksql
-    image: confluentinc/cp-ksql-cli:5.4.1
+    image: confluentinc/cp-ksql-cli:5.5.0
     command:
       - sh
       - -c

--- a/examples/zookeeper-client.yaml
+++ b/examples/zookeeper-client.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   containers:
   - name: zookeeper-client
-    image: confluentinc/cp-zookeeper:5.4.1
+    image: confluentinc/cp-zookeeper:5.5.0
     command:
       - sh
       - -c

--- a/grafana-dashboard/confluent-open-source-grafana-dashboard.json
+++ b/grafana-dashboard/confluent-open-source-grafana-dashboard.json
@@ -4350,7 +4350,7 @@
   "schemaVersion": 16,
   "style": "dark",
   "tags": [
-    "5.4.1"
+    "5.5.0"
   ],
   "templating": {
     "list": [

--- a/values.yaml
+++ b/values.yaml
@@ -132,7 +132,7 @@ cp-kafka-connect:
 ## ------------------------------------------------------
 cp-ksql-server:
   enabled: true
-  image: confluentinc/cp-ksql-server
+  image: confluentinc/cp-ksqldb-server
   imageTag: 5.5.0
   ## Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
   ## https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod

--- a/values.yaml
+++ b/values.yaml
@@ -5,7 +5,7 @@ cp-zookeeper:
   enabled: true
   servers: 3
   image: confluentinc/cp-zookeeper
-  imageTag: 5.4.1
+  imageTag: 5.5.0
   ## Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
   ## https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
   imagePullSecrets:
@@ -40,7 +40,7 @@ cp-kafka:
   enabled: true
   brokers: 3
   image: confluentinc/cp-enterprise-kafka
-  imageTag: 5.4.1
+  imageTag: 5.5.0
   ## Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
   ## https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
   imagePullSecrets:
@@ -67,7 +67,7 @@ cp-kafka:
 cp-schema-registry:
   enabled: true
   image: confluentinc/cp-schema-registry
-  imageTag: 5.4.1
+  imageTag: 5.5.0
   ## Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
   ## https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
   imagePullSecrets:
@@ -89,7 +89,7 @@ cp-schema-registry:
 cp-kafka-rest:
   enabled: true
   image: confluentinc/cp-kafka-rest
-  imageTag: 5.4.1
+  imageTag: 5.5.0
   ## Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
   ## https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
   imagePullSecrets:
@@ -111,7 +111,7 @@ cp-kafka-rest:
 cp-kafka-connect:
   enabled: true
   image: confluentinc/cp-kafka-connect
-  imageTag: 5.4.1
+  imageTag: 5.5.0
   ## Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
   ## https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
   imagePullSecrets:
@@ -133,7 +133,7 @@ cp-kafka-connect:
 cp-ksql-server:
   enabled: true
   image: confluentinc/cp-ksql-server
-  imageTag: 5.4.1
+  imageTag: 5.5.0
   ## Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
   ## https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
   imagePullSecrets:
@@ -148,7 +148,7 @@ cp-ksql-server:
 cp-control-center:
   enabled: true
   image: confluentinc/cp-enterprise-control-center
-  imageTag: 5.4.1
+  imageTag: 5.5.0
   ## Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
   ## https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
   imagePullSecrets:


### PR DESCRIPTION
* Latest CP release is 5.5.0
* KSQL branding renamed the image to `cp-ksqldb-server`

Instructions in release wiki: https://confluentinc.atlassian.net/wiki/spaces/TOOLS/pages/506233183/Promote+Release+to+Production#PromoteReleasetoProduction-Step9:PrepareforNextRelease(1-2hrs)