### PR TITLE
cp-kafka-rest: add customEnv

### DIFF
--- a/charts/cp-kafka-rest/README.md
+++ b/charts/cp-kafka-rest/README.md
@@ -113,6 +113,7 @@ The configuration parameters in this section control the resources requested and
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `configurationOverrides` | Kafka REST [configuration](https://docs.confluent.io/current/kafka-rest/docs/config.html) overrides in the dictionary format | `{}` |
+| `customEnv` | Custom environmental variables | `{}` |
 
 ### Confluent Kafka REST JVM Heap Options
 

--- a/charts/cp-kafka-rest/templates/deployment.yaml
+++ b/charts/cp-kafka-rest/templates/deployment.yaml
@@ -84,6 +84,10 @@ spec:
           - name: {{ printf "KAFKA_REST_%s" $key | replace "." "_" | upper | quote }}
             value: {{ $value | quote }}
           {{- end }}
+          {{- range $key, $value := .Values.customEnv }}
+          - name: {{ $key | quote }}
+            value: {{ $value | quote }}
+          {{- end }}
           {{- if .Values.jmx.port }}
           - name: KAFKA_REST_JMX_PORT
             value: "{{ .Values.jmx.port }}"

--- a/charts/cp-kafka-rest/values.yaml
+++ b/charts/cp-kafka-rest/values.yaml
@@ -51,6 +51,10 @@ tolerations: []
 configurationOverrides:
   # "consumer.request.timeout.ms": 5000
 
+## Additional env variables
+customEnv: {}
+  # ZOOKEEPER_SASL_ENABLED: "false"
+
 ## Monitoring
 ## Kafka REST JMX Settings
 ## ref: https://docs.confluent.io/current/kafka-rest/docs/monitoring.html


### PR DESCRIPTION
## What changes were proposed in this pull request?

add `customEnv` to cp-kafka-rest like cp-control-center, cp-kafka, cp-kafka-connect, cp-schema-registry

## How was this patch tested?

`helm install` on kind