### PR TITLE
add ZOOKEEPER_FORCE_SYNC env var to zookeeper

### DIFF
--- a/charts/cp-zookeeper/templates/statefulset.yaml
+++ b/charts/cp-zookeeper/templates/statefulset.yaml
@@ -101,6 +101,8 @@ spec:
         - name : KAFKA_JMX_PORT
           value: "{{ .Values.jmx.port }}"
         {{- end }}
+        - name : ZOOKEEPER_FORCE_SYNC
+          value: "{{ .Values.forceSync }}"
         - name : ZOOKEEPER_TICK_TIME
           value: "{{ .Values.tickTime }}"
         - name : ZOOKEEPER_SYNC_LIMIT

--- a/charts/cp-zookeeper/values.yaml
+++ b/charts/cp-zookeeper/values.yaml
@@ -44,6 +44,7 @@ initLimit: 10
 maxClientCnxns: 60
 autoPurgeSnapRetainCount: 3
 autoPurgePurgeInterval: 24
+forceSync: "yes"
 
 ## Zookeeper JVM Heap Option
 heapOptions: "-Xms512M -Xmx512M"


### PR DESCRIPTION
## What changes were proposed in this pull request?
Add the possibility to control the value of this important ZK variable.
In the slow cloud storage, setting the value to false is a must.
Otherwise, the cluster is not stable ...

## How was this patch tested?

(Please explain how this patch was tested. E.g. helm upgrade on minikube, helm install on gke)
