### PR TITLE
Fix the slow JMX metrics collection

### DIFF
--- a/charts/cp-kafka-connect/templates/jmx-configmap.yaml
+++ b/charts/cp-kafka-connect/templates/jmx-configmap.yaml
@@ -14,6 +14,10 @@ data:
     lowercaseOutputName: true
     lowercaseOutputLabelNames: true
     ssl: false
+    whitelistObjectNames:
+    - kafka.connect:type=connect-worker-metrics
+    - kafka.connect:type=connect-metrics, client-id=*
+    - kafka.connect:type=connector-task-metrics, connector=*, task=*
     rules:
     - pattern : "kafka.connect<type=connect-worker-metrics>([^:]+):"
       name: "cp_kafka_connect_connect_worker_metrics_$1"

--- a/charts/cp-kafka-rest/templates/jmx-configmap.yaml
+++ b/charts/cp-kafka-rest/templates/jmx-configmap.yaml
@@ -14,6 +14,9 @@ data:
     lowercaseOutputName: true
     lowercaseOutputLabelNames: true
     ssl: false
+    whitelistObjectNames:
+    - kafka.rest:type=jetty-metrics
+    - kafka.rest:type=jersey-metrics
     rules:
     - pattern : 'kafka.rest<type=jetty-metrics>([^:]+):'
       name: "cp_kafka_rest_jetty_metrics_$1"

--- a/charts/cp-kafka/templates/jmx-configmap.yaml
+++ b/charts/cp-kafka/templates/jmx-configmap.yaml
@@ -14,6 +14,16 @@ data:
     lowercaseOutputName: true
     lowercaseOutputLabelNames: true
     ssl: false
+    whitelistObjectNames:
+    - kafka.server:type=ReplicaManager, name=*
+    - kafka.controller:type=KafkaController, name=*
+    - kafka.server:type=BrokerTopicMetrics, name=*
+    - kafka.network:type=RequestMetrics, name=RequestsPerSec, request=*
+    - kafka.network:type=SocketServer, name=NetworkProcessorAvgIdlePercent
+    - kafka.server:type=ReplicaFetcherManager, name=MaxLag, clientId=*
+    - kafka.server:type=KafkaRequestHandlerPool, name=RequestHandlerAvgIdlePercent
+    - kafka.controller:type=ControllerStats, name=*
+    - kafka.server:type=SessionExpireListener, name=*
     rules:
     - pattern : kafka.server<type=ReplicaManager, name=(.+)><>(Value|OneMinuteRate)
       name: "cp_kafka_server_replicamanager_$1"

--- a/charts/cp-ksql-server/templates/jmx-configmap.yaml
+++ b/charts/cp-ksql-server/templates/jmx-configmap.yaml
@@ -14,6 +14,8 @@ data:
     lowercaseOutputName: true
     lowercaseOutputLabelNames: true
     ssl: false
+    whitelistObjectNames:
+    - io.confluent.ksql.metrics:type=ksql-engine-query-stats
     rules:
     - pattern : 'io.confluent.ksql.metrics<type=ksql-engine-query-stats>([^:]+):'
       name: "cp_ksql_server_metrics_$1"

--- a/charts/cp-schema-registry/templates/jmx-configmap.yaml
+++ b/charts/cp-schema-registry/templates/jmx-configmap.yaml
@@ -14,6 +14,10 @@ data:
     lowercaseOutputName: true
     lowercaseOutputLabelNames: true
     ssl: false
+    whitelistObjectNames:
+    - kafka.schema.registry:type=jetty-metrics
+    - kafka.schema.registry:type=master-slave-role
+    - kafka.schema.registry:type=jersey-metrics
     rules:
     - pattern : 'kafka.schema.registry<type=jetty-metrics>([^:]+):'
       name: "cp_kafka_schema_registry_jetty_metrics_$1"

--- a/charts/cp-zookeeper/templates/jmx-configmap.yaml
+++ b/charts/cp-zookeeper/templates/jmx-configmap.yaml
@@ -14,6 +14,11 @@ data:
     lowercaseOutputName: true
     lowercaseOutputLabelNames: true
     ssl: false
+    whitelistObjectNames:
+    - org.apache.ZooKeeperService:name0=ReplicatedServer_id*
+    - org.apache.ZooKeeperService:name0=ReplicatedServer_id*, name1=replica.*
+    - org.apache.ZooKeeperService:name0=ReplicatedServer_id*, name1=replica.*, name2=*
+    - org.apache.ZooKeeperService:name0=ReplicatedServer_id*, name1=replica.*, name2=*, name3=*
     rules:
     - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+)><>(\\w+)"
       name: "cp_zookeeper_$2"


### PR DESCRIPTION
## What changes were proposed in this pull request?

On our clusters metrics are collected every 10-15 seconds, the default configuration would cause Prometheus scrape timeout from time to time since JMX collection could take longer than the timeout threshold.

This PR whitelists only the metrics used in rules for JMX exporting. Normally, [JMX collection is slow](https://github.com/prometheus/jmx_exporter/issues/175#issuecomment-559029237) so this PR based on the https://github.com/prometheus/jmx_exporter/issues/246 solves that.

Whitelists are build based on [this document](https://docs.oracle.com/javase/6/docs/api/javax/management/ObjectName.html).

## How was this patch tested?

Extracted commit out of the upgrade on real clusters (running Kubernetes v1.17.4). Our test keeps showing the same metrics as before using the Confluent Grafana chart. After this patch times fell from around 10 seconds down to about 0.1s.

Note: We are not running the KSQL nor schema registry so those were not tested on the production-grade cluster.