### PR TITLE
Fix rolling updates

### DIFF
--- a/charts/cp-kafka/templates/statefulset.yaml
+++ b/charts/cp-kafka/templates/statefulset.yaml
@@ -81,6 +81,12 @@ spec:
       - name: {{ template "cp-kafka.name" . }}-broker
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+        readinessProbe:
+         tcpSocket:
+           port: 9092
+         initialDelaySeconds: 10
+         periodSeconds: 10
+
         ports:
         - containerPort: 9092
           name: kafka

--- a/charts/cp-zookeeper/README.md
+++ b/charts/cp-zookeeper/README.md
@@ -145,6 +145,13 @@ The configuration parameters in this section control the resources requested and
 | `leaderElectionPort` | The port on which the ZooKeeper servers perform leader election. | `3888` |
 | `clientPort` | The port to listen for client connections; that is, the port that clients attempt to connect to. | `2181` |
 
+### Confluent Zookeeper Configuration
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `configurationOverrides` | Zookeeper [configuration](https://zookeeper.apache.org/doc/r3.2.2/zookeeperAdmin.html#sc_configuration) overrides in the dictionary format | `{}` |
+
+
 ### Persistence
 
 | Parameter | Description | Default |

--- a/charts/cp-zookeeper/templates/statefulset.yaml
+++ b/charts/cp-zookeeper/templates/statefulset.yaml
@@ -123,6 +123,10 @@ spec:
           valueFrom:
             fieldRef:
               fieldPath: metadata.name
+        {{- range $key, $value := .Values.configurationOverrides }}
+        - name: {{ printf "ZOOKEEPER_%s" $key | replace "." "_" | upper | quote }}
+          value: {{ $value | quote }}
+        {{- end }}
         command:
         - "bash"
         - "-c"


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add readinessProbe to Kafka 

## How was this patch tested?

* 3 kafka brokers
* run rollingupdates against a running deployment: k8s will bring down the kafka instances one by one. next instance goes down when previous instance's state is 'Running'. Without this patch the newly updated kafka is not yet ready when the next instance goes down. 
With this patch, you will see that k8s is waiting for the newly updated instance to be ready, before bringing down the next one. 
 This way, you have HA when rolling updates are running
