### PR TITLE
fix: Fix the JMX whitespace regression

### DIFF
--- a/charts/cp-kafka-connect/templates/jmx-configmap.yaml
+++ b/charts/cp-kafka-connect/templates/jmx-configmap.yaml
@@ -16,8 +16,8 @@ data:
     ssl: false
     whitelistObjectNames:
     - kafka.connect:type=connect-worker-metrics
-    - kafka.connect:type=connect-metrics, client-id=*
-    - kafka.connect:type=connector-task-metrics, connector=*, task=*
+    - kafka.connect:type=connect-metrics,client-id=*
+    - kafka.connect:type=connector-task-metrics,connector=*,task=*
     rules:
     - pattern : "kafka.connect<type=connect-worker-metrics>([^:]+):"
       name: "cp_kafka_connect_connect_worker_metrics_$1"

--- a/charts/cp-kafka/templates/jmx-configmap.yaml
+++ b/charts/cp-kafka/templates/jmx-configmap.yaml
@@ -15,15 +15,15 @@ data:
     lowercaseOutputLabelNames: true
     ssl: false
     whitelistObjectNames:
-    - kafka.server:type=ReplicaManager, name=*
-    - kafka.controller:type=KafkaController, name=*
-    - kafka.server:type=BrokerTopicMetrics, name=*
-    - kafka.network:type=RequestMetrics, name=RequestsPerSec, request=*
-    - kafka.network:type=SocketServer, name=NetworkProcessorAvgIdlePercent
-    - kafka.server:type=ReplicaFetcherManager, name=MaxLag, clientId=*
-    - kafka.server:type=KafkaRequestHandlerPool, name=RequestHandlerAvgIdlePercent
-    - kafka.controller:type=ControllerStats, name=*
-    - kafka.server:type=SessionExpireListener, name=*
+    - kafka.server:type=ReplicaManager,name=*
+    - kafka.controller:type=KafkaController,name=*
+    - kafka.server:type=BrokerTopicMetrics,name=*
+    - kafka.network:type=RequestMetrics,name=RequestsPerSec,request=*
+    - kafka.network:type=SocketServer,name=NetworkProcessorAvgIdlePercent
+    - kafka.server:type=ReplicaFetcherManager,name=MaxLag,clientId=*
+    - kafka.server:type=KafkaRequestHandlerPool,name=RequestHandlerAvgIdlePercent
+    - kafka.controller:type=ControllerStats,name=*
+    - kafka.server:type=SessionExpireListener,name=*
     rules:
     - pattern : kafka.server<type=ReplicaManager, name=(.+)><>(Value|OneMinuteRate)
       name: "cp_kafka_server_replicamanager_$1"

--- a/charts/cp-zookeeper/templates/jmx-configmap.yaml
+++ b/charts/cp-zookeeper/templates/jmx-configmap.yaml
@@ -16,9 +16,9 @@ data:
     ssl: false
     whitelistObjectNames:
     - org.apache.ZooKeeperService:name0=ReplicatedServer_id*
-    - org.apache.ZooKeeperService:name0=ReplicatedServer_id*, name1=replica.*
-    - org.apache.ZooKeeperService:name0=ReplicatedServer_id*, name1=replica.*, name2=*
-    - org.apache.ZooKeeperService:name0=ReplicatedServer_id*, name1=replica.*, name2=*, name3=*
+    - org.apache.ZooKeeperService:name0=ReplicatedServer_id*,name1=replica.*
+    - org.apache.ZooKeeperService:name0=ReplicatedServer_id*,name1=replica.*,name2=*
+    - org.apache.ZooKeeperService:name0=ReplicatedServer_id*,name1=replica.*,name2=*,name3=*
     rules:
     - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+)><>(\\w+)"
       name: "cp_zookeeper_$2"


### PR DESCRIPTION
## What changes were proposed in this pull request?

This fixes the regression from my previous PR https://github.com/confluentinc/cp-helm-charts/pull/428 which was due to formatting with whitespaces to make it consistent with the patterns below. It didn't show on the previous PR since it only affected some metrics.

## How was this patch tested?

Tested with the complete Grafana dashboard and short enough refresh interval (30m refreshed every 15s) not to use the old values.

Apologies for the inconvenience.