### PR TITLE
Toggle enterprise feature

### DIFF
--- a/charts/cp-kafka/Chart.yaml
+++ b/charts/cp-kafka/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Confluent Kafka on Kubernetes
 name: cp-kafka
-version: 0.1.0
+version: 0.1.1

--- a/charts/cp-kafka/README.md
+++ b/charts/cp-kafka/README.md
@@ -118,6 +118,7 @@ The configuration parameters in this section control the resources requested and
 | `imageTag` | Docker Image Tag of Confluent Kafka. | `5.5.0` |
 | `imagePullPolicy` | Docker Image Tag of Confluent Kafka. | `IfNotPresent` |
 | `imagePullSecrets` | Secrets to be used for private registries. | see [values.yaml](values.yaml) for details |
+| `enableEnterpriseFeatures` | If enterprise feautres shall be enabled. Requries the image to be `confluentinc/cp-enterprise-kafka`. If disabled, it works with `confluentinc/cp-kafka` | `true`
 
 ### StatefulSet Configurations
 

--- a/charts/cp-kafka/templates/statefulset.yaml
+++ b/charts/cp-kafka/templates/statefulset.yaml
@@ -121,10 +121,12 @@ spec:
           value: {{ include "cp-kafka.cp-zookeeper.service-name" . | quote }}
         - name: KAFKA_LOG_DIRS
           value: {{ include "cp-kafka.log.dirs" . | quote }}
+        {{- if .Values.enableEnterpriseFeatures }}
         - name: KAFKA_METRIC_REPORTERS
           value: "io.confluent.metrics.reporter.ConfluentMetricsReporter"
         - name: CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS
           value: {{ printf "PLAINTEXT://%s:9092" (include "cp-kafka.cp-kafka-headless.fullname" .) | quote }}
+        {{- end }}
         {{- range $key, $value := .Values.configurationOverrides }}
         - name: {{ printf "KAFKA_%s" $key | replace "." "_" | upper | quote }}
           value: {{ $value | quote }}

--- a/charts/cp-kafka/values.yaml
+++ b/charts/cp-kafka/values.yaml
@@ -128,6 +128,8 @@ nodeport:
   servicePort: 19092
   firstListenerPort: 31090
 
+enableEnterpriseFeatures: true
+
 ## ------------------------------------------------------
 ## Zookeeper
 ## ------------------------------------------------------

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -26,4 +26,4 @@ dependencies:
 - name: cp-control-center
   version: 0.1.0
   repository: file://./charts/cp-control-center
-  condition: cp-control-center.enabled
+  condition: cp-kafka.enableEnterpriseFeatures, cp-control-center.enabled

--- a/requirements.yaml
+++ b/requirements.yaml
@@ -1,6 +1,6 @@
 dependencies:
 - name: cp-kafka
-  version: 0.1.0
+  version: 0.1.1
   repository: file://./charts/cp-kafka
   condition: cp-kafka.enabled
 - name: cp-zookeeper


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add a variable to cp-kafka/values.yaml to enable or disable enterprise
features. Currently this only means enabling or disabling the
ConfluentMetricsReporter and some configuration for it. Doing this
allows us to use open source Kafka docker image without changing
anything in the chart.

Fixes #377 

This PR is completely based on the work of @oscarh on #378 with just a small change to fulfill the request to disable the control center when `enableEnterpriseFeatures=false`: I simply flipped the order of 
```yaml
condition: cp-kafka.enableEnterpriseFeatures, cp-control-center.enabled
```

## How was this patch tested?
```bash
helm template --set cp-kafka.enableEnterpriseFeatures=false . > ~/tmp/kafka_enterprise_disabled.yaml
helm template --set cp-kafka.enableEnterpriseFeatures=true . > ~/tmp/kafka_enterprise_enabled.yaml
diff -u ~/tmp/kafka_enterprise_{enabled,disabled}.yaml
```
```
--- /Users/niki/tmp/kafka_enterprise_enabled.yaml	2020-05-23 03:22:46.000000000 +0200
+++ /Users/niki/tmp/kafka_enterprise_disabled.yaml	2020-05-23 03:23:00.000000000 +0200
@@ -241,24 +241,6 @@
         replicaId: "$2"
         memberType: "$3"
 ---
-# Source: cp-helm-charts/charts/cp-control-center/templates/service.yaml
-apiVersion: v1
-kind: Service
-metadata:
-  name: RELEASE-NAME-cp-control-center
-  labels:
-    app: cp-control-center
-    chart: cp-control-center-0.1.0
-    release: RELEASE-NAME
-    heritage: Helm
-spec:
-  ports:
-    - name: cc-http
-      port: 9021
-  selector:
-    app: cp-control-center
-    release: RELEASE-NAME
----
 # Source: cp-helm-charts/charts/cp-kafka-connect/templates/service.yaml
 apiVersion: v1
 kind: Service
@@ -408,59 +390,6 @@
     app: cp-zookeeper
     release: RELEASE-NAME
 ---
-# Source: cp-helm-charts/charts/cp-control-center/templates/deployment.yaml
-apiVersion: apps/v1
-kind: Deployment
-metadata:
-  name: RELEASE-NAME-cp-control-center
-  labels:
-    app: cp-control-center
-    chart: cp-control-center-0.1.0
-    release: RELEASE-NAME
-    heritage: Helm
-spec:
-  replicas: 1
-  selector:
-    matchLabels:
-      app: cp-control-center
-      release: RELEASE-NAME
-  template:
-    metadata:
-      labels:
-        app: cp-control-center
-        release: RELEASE-NAME
-      annotations:
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "5556"
-    spec:
-      containers:
-        - name: cp-control-center
-          image: "confluentinc/cp-enterprise-control-center:5.5.0"
-          imagePullPolicy: IfNotPresent
-          ports:
-            - name: cc-http
-              containerPort: 9021
-              protocol: TCP
-          resources:
-            {}
-          env:
-            - name: CONTROL_CENTER_BOOTSTRAP_SERVERS
-              value: PLAINTEXT://RELEASE-NAME-cp-kafka-headless:9092
-            - name: CONTROL_CENTER_ZOOKEEPER_CONNECT
-              value:
-            - name: CONTROL_CENTER_CONNECT_CLUSTER
-              value: http://RELEASE-NAME-cp-kafka-connect:8083
-            - name: CONTROL_CENTER_KSQL_URL
-              value: http://RELEASE-NAME-cp-ksql-server:8088
-            - name: CONTROL_CENTER_KSQL_ADVERTISED_URL
-              value: http://RELEASE-NAME-cp-ksql-server:8088
-            - name: CONTROL_CENTER_SCHEMA_REGISTRY_URL
-              value: http://RELEASE-NAME-cp-schema-registry:8081
-            - name: KAFKA_HEAP_OPTS
-              value: "-Xms512M -Xmx512M"
-            - name: "CONTROL_CENTER_REPLICATION_FACTOR"
-              value: "3"
----
 # Source: cp-helm-charts/charts/cp-kafka-connect/templates/deployment.yaml
 apiVersion: apps/v1
 kind: Deployment
@@ -896,10 +825,6 @@
           value: "RELEASE-NAME-cp-zookeeper-headless:2181"
         - name: KAFKA_LOG_DIRS
           value: "/opt/kafka/data-0/logs"
-        - name: KAFKA_METRIC_REPORTERS
-          value: "io.confluent.metrics.reporter.ConfluentMetricsReporter"
-        - name: CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS
-          value: "PLAINTEXT://RELEASE-NAME-cp-kafka-headless:9092"
         - name: "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP"
           value: "PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT"
         - name: "KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR"
```

@gAmUssA can you take a look, please?
