### PR TITLE
Fix JMX metrics not enabled correctly

### DIFF
--- a/charts/cp-ksql-server/templates/deployment.yaml
+++ b/charts/cp-ksql-server/templates/deployment.yaml
@@ -95,7 +95,7 @@ spec:
             value: {{ $value | quote }}
           {{- end }}
           {{- if .Values.jmx.port }}
-          - name: KSQL_JMX_PORT
+          - name: JMX_PORT
             value: "{{ .Values.jmx.port }}"
           {{- end }}
       {{- if .Values.imagePullSecrets }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Set the JMX_PORT environment variable as described [here](https://docs.ksqldb.io/en/latest/operate-and-deploy/installation/server-config/#jmx-metrics)

Fixes #304 

## How was this patch tested?

helm install on EKS
