### PR TITLE
Updated connection scripts to be more simple and actually usable

### DIFF
--- a/charts/cp-kafka-connect/README.md
+++ b/charts/cp-kafka-connect/README.md
@@ -4,18 +4,18 @@ This chart bootstraps a deployment of a Confluent Kafka Connect
 
 ## Prerequisites
 
-* Kubernetes 1.9.2+
-* Helm 2.8.2+
-* A healthy and accessible Kafka Cluster
+- Kubernetes 1.9.2+
+- Helm 2.8.2+
+- A healthy and accessible Kafka Cluster
 
 ## Developing Environment:
 
-* [Pivotal Container Service (PKS)](https://pivotal.io/platform/pivotal-container-service)
-* [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine/)
+- [Pivotal Container Service (PKS)](https://pivotal.io/platform/pivotal-container-service)
+- [Google Kubernetes Engine (GKE)](https://cloud.google.com/kubernetes-engine/)
 
 ## Docker Image Source:
 
-* [DockerHub -> ConfluentInc](https://hub.docker.com/u/confluentinc/)
+- [DockerHub -> ConfluentInc](https://hub.docker.com/u/confluentinc/)
 
 ## Installing the Chart
 
@@ -65,6 +65,7 @@ kissing-macaw-cp-kafka-connect-6c77b8f5fd-cqlzq  1/1    Running  0         34m
 ```
 
 There are
+
 1. A [Deployment](https://kubernetes.io/docs/concepts/workloads/controllers/deployment/) `kissing-macaw-cp-kafka-connect` which contains 1 Kafka Connect [Pod](https://kubernetes.io/docs/concepts/workloads/pods/pod-overview/): `kissing-macaw-cp-kafka-connect-6c77b8f5fd-cqlzq`.
 2. A [Service](https://kubernetes.io/docs/concepts/services-networking/service/) `kissing-macaw-cp-kafka-connect` for clients to connect to Kafka Connect REST endpoint.
 
@@ -84,101 +85,93 @@ helm install --name my-kafka-connect -f my-values.yaml ./cp-kafka-connect
 
 The configuration parameters in this section control the resources requested and utilized by the `cp-kafka-connect` chart.
 
-| Parameter         | Description                           | Default   |
-| ----------------- | ------------------------------------- | --------- |
-| `replicaCount`    | The number of Kafka Connect Servers.  | `1`       |
+| Parameter      | Description                          | Default |
+| -------------- | ------------------------------------ | ------- |
+| `replicaCount` | The number of Kafka Connect Servers. | `1`     |
 
 ### Image
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `image` | Docker Image of Confluent Kafka Connect. | `confluentinc/cp-kafka-connect` |
-| `imageTag` | Docker Image Tag of Confluent Kafka Connect. | `5.5.0` |
-| `imagePullPolicy` | Docker Image Tag of Confluent Kafka Connect. | `IfNotPresent` |
-| `imagePullSecrets` | Secrets to be used for private registries. | see [values.yaml](values.yaml) for details |
+| Parameter          | Description                                  | Default                                    |
+| ------------------ | -------------------------------------------- | ------------------------------------------ |
+| `image`            | Docker Image of Confluent Kafka Connect.     | `confluentinc/cp-kafka-connect`            |
+| `imageTag`         | Docker Image Tag of Confluent Kafka Connect. | `5.5.0`                                    |
+| `imagePullPolicy`  | Docker Image Tag of Confluent Kafka Connect. | `IfNotPresent`                             |
+| `imagePullSecrets` | Secrets to be used for private registries.   | see [values.yaml](values.yaml) for details |
 
 ### Port
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `servicePort` | The port on which the Kafka Connect will be available and serving requests. | `8083` |
+| Parameter     | Description                                                                 | Default |
+| ------------- | --------------------------------------------------------------------------- | ------- |
+| `servicePort` | The port on which the Kafka Connect will be available and serving requests. | `8083`  |
 
 ### Kafka Connect Worker Configurations
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `configurationOverrides` | Kafka Connect [configuration](https://docs.confluent.io/current/connect/references/allconfigs.html) overrides in the dictionary format. | `{}` |
-| `customEnv` | Custom environmental variables | `{}` |
+| Parameter                | Description                                                                                                                             | Default |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `configurationOverrides` | Kafka Connect [configuration](https://docs.confluent.io/current/connect/references/allconfigs.html) overrides in the dictionary format. | `{}`    |
+| `customEnv`              | Custom environmental variables                                                                                                          | `{}`    |
 
-### Volumes
+### configScripts
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `volumes` | Volumes for connect-server container | see [values.yaml](values.yaml) for details |
-| `volumeMounts` | Volume mounts for connect-server container | see [values.yaml](values.yaml) for details |
+| Parameter      | Description                                                    | Default                                    |
+| -------------- | -------------------------------------------------------------- | ------------------------------------------ |
+| `configScript` | Creates mounted files (.sh files) for later running on service | see [values.yaml](values.yaml) for details |
 
-### Secrets
+### runScripts
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `secrets` | Secret with one or more `key:value` pairs | see [values.yaml](values.yaml) for details |
+| Parameter    | Description                                              | Default                                    |
+| ------------ | -------------------------------------------------------- | ------------------------------------------ |
+| `runScripts` | When set true will run all configScripts during start up | see [values.yaml](values.yaml) for details |
 
 ### Kafka Connect JVM Heap Options
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
+| Parameter     | Description                            | Default               |
+| ------------- | -------------------------------------- | --------------------- |
 | `heapOptions` | The JVM Heap Options for Kafka Connect | `"-Xms512M -Xmx512M"` |
 
 ### Resources
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `resources.requests.cpu` | The amount of CPU to request. | see [values.yaml](values.yaml) for details |
-| `resources.requests.memory` | The amount of memory to request. | see [values.yaml](values.yaml) for details |
-| `resources.requests.limit` | The upper limit CPU usage for a Kafka Connect Pod. | see [values.yaml](values.yaml) for details |
-| `resources.requests.limit` | The upper limit memory usage for a Kafka Connect Pod. | see [values.yaml](values.yaml) for details |
+| Parameter                   | Description                                           | Default                                    |
+| --------------------------- | ----------------------------------------------------- | ------------------------------------------ |
+| `resources.requests.cpu`    | The amount of CPU to request.                         | see [values.yaml](values.yaml) for details |
+| `resources.requests.memory` | The amount of memory to request.                      | see [values.yaml](values.yaml) for details |
+| `resources.requests.limit`  | The upper limit CPU usage for a Kafka Connect Pod.    | see [values.yaml](values.yaml) for details |
+| `resources.requests.limit`  | The upper limit memory usage for a Kafka Connect Pod. | see [values.yaml](values.yaml) for details |
 
 ### Annotations
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `podAnnotations` | Map of custom annotations to attach to the pod spec. | `{}` |
+| Parameter        | Description                                          | Default |
+| ---------------- | ---------------------------------------------------- | ------- |
+| `podAnnotations` | Map of custom annotations to attach to the pod spec. | `{}`    |
 
 ### JMX Configuration
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `jmx.port` | The jmx port which JMX style metrics are exposed. | `5555` |
+| Parameter  | Description                                       | Default |
+| ---------- | ------------------------------------------------- | ------- |
+| `jmx.port` | The jmx port which JMX style metrics are exposed. | `5555`  |
 
 ### Prometheus JMX Exporter Configuration
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `prometheus.jmx.enabled` | Whether or not to install Prometheus JMX Exporter as a sidecar container and expose JMX metrics to Prometheus. | `true` |
-| `prometheus.jmx.image` | Docker Image for Prometheus JMX Exporter container. | `solsson/kafka-prometheus-jmx-exporter@sha256` |
-| `prometheus.jmx.imageTag` | Docker Image Tag for Prometheus JMX Exporter container. | `6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143` |
-| `prometheus.jmx.imagePullPolicy` | Docker Image Pull Policy for Prometheus JMX Exporter container. | `IfNotPresent` |
-| `prometheus.jmx.port` | JMX Exporter Port which exposes metrics in Prometheus format for scraping. | `5556` |
-| `prometheus.jmx.resources` | JMX Exporter resources configuration. | see [values.yaml](values.yaml) for details |
-
-### Running Custom Scripts
-
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `customEnv.CUSTOM_SCRIPT_PATH` | Path to external bash script to run inside the container | see [values.yaml](values.yaml) for details |
-| `livenessProbe` | Requirement of `livenessProbe` depends on the custom script to be run  | see [values.yaml](values.yaml) for details |
+| Parameter                        | Description                                                                                                    | Default                                                            |
+| -------------------------------- | -------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------ |
+| `prometheus.jmx.enabled`         | Whether or not to install Prometheus JMX Exporter as a sidecar container and expose JMX metrics to Prometheus. | `true`                                                             |
+| `prometheus.jmx.image`           | Docker Image for Prometheus JMX Exporter container.                                                            | `solsson/kafka-prometheus-jmx-exporter@sha256`                     |
+| `prometheus.jmx.imageTag`        | Docker Image Tag for Prometheus JMX Exporter container.                                                        | `6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143` |
+| `prometheus.jmx.imagePullPolicy` | Docker Image Pull Policy for Prometheus JMX Exporter container.                                                | `IfNotPresent`                                                     |
+| `prometheus.jmx.port`            | JMX Exporter Port which exposes metrics in Prometheus format for scraping.                                     | `5556`                                                             |
+| `prometheus.jmx.resources`       | JMX Exporter resources configuration.                                                                          | see [values.yaml](values.yaml) for details                         |
 
 ### Deployment Topology
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `nodeSelector` | Dictionary containing key-value-pairs to match labels on nodes. When defined pods will only be scheduled on nodes, that have each of the indicated key-value pairs as labels. Further information can be found in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) | `{}`
-| `tolerations`| Array containing taint references. When defined, pods can run on nodes, which would otherwise deny scheduling. Further information can be found in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) | `{}`
+| Parameter      | Description                                                                                                                                                                                                                                                                                                          | Default |
+| -------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------- |
+| `nodeSelector` | Dictionary containing key-value-pairs to match labels on nodes. When defined pods will only be scheduled on nodes, that have each of the indicated key-value pairs as labels. Further information can be found in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) | `{}`    |
+| `tolerations`  | Array containing taint references. When defined, pods can run on nodes, which would otherwise deny scheduling. Further information can be found in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/)                                                           | `{}`    |
 
 ## Dependencies
 
 ### Kafka
 
-| Parameter | Description | Default |
-| --------- | ----------- | ------- |
-| `kafka.bootstrapServers` | Bootstrap Servers for Kafka Connect | `""` |
+| Parameter                | Description                         | Default |
+| ------------------------ | ----------------------------------- | ------- |
+| `kafka.bootstrapServers` | Bootstrap Servers for Kafka Connect | `""`    |

--- a/charts/cp-kafka-connect/README.md
+++ b/charts/cp-kafka-connect/README.md
@@ -93,7 +93,7 @@ The configuration parameters in this section control the resources requested and
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
 | `image` | Docker Image of Confluent Kafka Connect. | `confluentinc/cp-kafka-connect` |
-| `imageTag` | Docker Image Tag of Confluent Kafka Connect. | `5.0.0` |
+| `imageTag` | Docker Image Tag of Confluent Kafka Connect. | `5.5.0` |
 | `imagePullPolicy` | Docker Image Tag of Confluent Kafka Connect. | `IfNotPresent` |
 | `imagePullSecrets` | Secrets to be used for private registries. | see [values.yaml](values.yaml) for details |
 
@@ -101,19 +101,33 @@ The configuration parameters in this section control the resources requested and
 
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
-| `servicePort` | The port on which the Kafka Connect will be available and serving requests. | `8082` |
+| `servicePort` | The port on which the Kafka Connect will be available and serving requests. | `8083` |
 
 ### Kafka Connect Worker Configurations
 
 | Parameter | Description | Default |
 | --------- | ----------- | ------- |
-| `connectKeyConverter` | Converter class for key Connect data. This controls the format of the data that will be written to Kafka for source connectors or read from Kafka for sink connectors. Popular formats include Avro and JSON. |`"io.confluent.connect.avro.AvroConverter"`|
-| `connectValueConverter` | Converter class for value Connect data. This controls the format of the data that will be written to Kafka for source connectors or read from Kafka for sink connectors. Popular formats include Avro and JSON. |`"io.confluent.connect.avro.AvroConverter"`|
-| `connectKeyConverterSchemaEnable` | Whether or not the converter class for key will have schema enabled.  |`true`|
-| `connectValueConverterSchemaEnable` | Whether or not the converter class for value will have schema enabled. |`true`|
-| `connectInternalKeyConverter` | Converter class for internal key Connect data that implements the Converter interface. Used for converting data like offsets and configs. |`"org.apache.kafka.connect.json.JsonConverter"`|
-| `connectInternalValueConverter` | Converter class for offset value Connect data that implements the Converter interface. Used for converting data like offsets and configs. |`"org.apache.kafka.connect.json.JsonConverter"`|
-| `pluginPath` | The comma-separated list of paths to directories that contain Kafka Connect plugins. |`"/usr/share/java"`|
+| `configurationOverrides` | Kafka Connect [configuration](https://docs.confluent.io/current/connect/references/allconfigs.html) overrides in the dictionary format. | `{}` |
+| `customEnv` | Custom environmental variables | `{}` |
+
+### Volumes
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `volumes` | Volumes for connect-server container | see [values.yaml](values.yaml) for details |
+| `volumeMounts` | Volume mounts for connect-server container | see [values.yaml](values.yaml) for details |
+
+### Secrets
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `secrets` | Secret with one or more `key:value` pairs | see [values.yaml](values.yaml) for details |
+
+### Kafka Connect JVM Heap Options
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `heapOptions` | The JVM Heap Options for Kafka Connect | `"-Xms512M -Xmx512M"` |
 
 ### Resources
 
@@ -123,6 +137,12 @@ The configuration parameters in this section control the resources requested and
 | `resources.requests.memory` | The amount of memory to request. | see [values.yaml](values.yaml) for details |
 | `resources.requests.limit` | The upper limit CPU usage for a Kafka Connect Pod. | see [values.yaml](values.yaml) for details |
 | `resources.requests.limit` | The upper limit memory usage for a Kafka Connect Pod. | see [values.yaml](values.yaml) for details |
+
+### Annotations
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `podAnnotations` | Map of custom annotations to attach to the pod spec. | `{}` |
 
 ### JMX Configuration
 
@@ -137,7 +157,23 @@ The configuration parameters in this section control the resources requested and
 | `prometheus.jmx.enabled` | Whether or not to install Prometheus JMX Exporter as a sidecar container and expose JMX metrics to Prometheus. | `true` |
 | `prometheus.jmx.image` | Docker Image for Prometheus JMX Exporter container. | `solsson/kafka-prometheus-jmx-exporter@sha256` |
 | `prometheus.jmx.imageTag` | Docker Image Tag for Prometheus JMX Exporter container. | `6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143` |
+| `prometheus.jmx.imagePullPolicy` | Docker Image Pull Policy for Prometheus JMX Exporter container. | `IfNotPresent` |
 | `prometheus.jmx.port` | JMX Exporter Port which exposes metrics in Prometheus format for scraping. | `5556` |
+| `prometheus.jmx.resources` | JMX Exporter resources configuration. | see [values.yaml](values.yaml) for details |
+
+### Running Custom Scripts
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `customEnv.CUSTOM_SCRIPT_PATH` | Path to external bash script to run inside the container | see [values.yaml](values.yaml) for details |
+| `livenessProbe` | Requirement of `livenessProbe` depends on the custom script to be run  | see [values.yaml](values.yaml) for details |
+
+### Deployment Topology
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `nodeSelector` | Dictionary containing key-value-pairs to match labels on nodes. When defined pods will only be scheduled on nodes, that have each of the indicated key-value pairs as labels. Further information can be found in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/assign-pod-node/) | `{}`
+| `tolerations`| Array containing taint references. When defined, pods can run on nodes, which would otherwise deny scheduling. Further information can be found in the [Kubernetes documentation](https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/) | `{}`
 
 ## Dependencies
 

--- a/charts/cp-kafka-connect/templates/config-scripts.yaml
+++ b/charts/cp-kafka-connect/templates/config-scripts.yaml
@@ -1,16 +1,16 @@
-{{- if .Values.secrets }}
+{{- if .Values.configScripts }}
 apiVersion: v1
-kind: Secret
+kind: ConfigMap
 metadata:
-  name: {{ template "cp-kafka-connect.fullname" . }}
+  name: {{ template "cp-kafka-connect.fullname" . }}-config-scripts
   labels:
     app: {{ template "cp-kafka-connect.name" . }}
     chart: {{ template "cp-kafka-connect.chart" . }}
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
-type: Opaque
 data:
-  {{- range $key, $value := .Values.secrets }}
-    {{ $key }}: {{ $value | b64enc }}
-  {{- end }}
+{{- range $key, $value := .Values.configScripts }}
+  {{ $key }}: |
+{{ $value | indent 4 }}
+{{- end }}
 {{- end }}

--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -136,7 +136,7 @@ spec:
       - name: config-scripts
         configMap:
           name: {{ template "cp-kafka-connect.fullname" . }}-config-scripts
-          defaultMode: 777
+          defaultMode:  0777
       {{- end }}
       {{- if .Values.prometheus.jmx.enabled }}
       - name: jmx-config

--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -1,4 +1,8 @@
+{{- if .Capabilities.APIVersions.Has "apps/v1" }}
+apiVersion: apps/v1
+{{- else }}
 apiVersion: apps/v1beta2
+{{- end }}
 kind: Deployment
 metadata:
   name: {{ template "cp-kafka-connect.fullname" . }}
@@ -18,16 +22,22 @@ spec:
       labels:
         app: {{ template "cp-kafka-connect.name" . }}
         release: {{ .Release.Name }}
-      {{- if .Values.prometheus.jmx.enabled }}
+      {{- if or .Values.podAnnotations .Values.prometheus.jmx.enabled }}
       annotations:
+      {{- range $key, $value := .Values.podAnnotations }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- if .Values.prometheus.jmx.enabled }}
         prometheus.io/scrape: "true"
         prometheus.io/port: {{ .Values.prometheus.jmx.port | quote }}
+      {{- end }}
       {{- end }}
     spec:
       containers:
         {{- if .Values.prometheus.jmx.enabled }}
         - name: prometheus-jmx-exporter
           image: "{{ .Values.prometheus.jmx.image }}:{{ .Values.prometheus.jmx.imageTag }}"
+          imagePullPolicy: "{{ .Values.prometheus.jmx.imagePullPolicy }}"
           command:
           - java
           - -XX:+UnlockExperimentalVMOptions
@@ -63,9 +73,7 @@ spec:
             - name: CONNECT_REST_ADVERTISED_HOST_NAME
               valueFrom:
                 fieldRef:
-                  fieldPath: metadata.name
-            - name: CONNECT_PLUGIN_PATH
-              value: {{ .Values.pluginPath }}
+                  fieldPath: status.podIP
             - name: CONNECT_BOOTSTRAP_SERVERS
               value: {{ template "cp-kafka-connect.kafka.bootstrapServers" . }}
             - name: CONNECT_GROUP_ID
@@ -80,29 +88,55 @@ spec:
               value: {{ template "cp-kafka-connect.cp-schema-registry.service-name" .}}
             - name: CONNECT_VALUE_CONVERTER_SCHEMA_REGISTRY_URL
               value: {{ template "cp-kafka-connect.cp-schema-registry.service-name" .}}
-            - name: CONNECT_KEY_CONVERTER
-              value: {{ .Values.connectKeyConverter }}
-            - name: CONNECT_VALUE_CONVERTER
-              value: {{ .Values.connectValueConverter }}
-            - name: CONNECT_KEY_CONVERTER_SCHEMAS_ENABLE
-              value: "{{ .Values.connectKeyConverterSchemaEnable }}"
-            - name: CONNECT_VALUE_CONVERTER_SCHEMAS_ENABLE
-              value: "{{ .Values.connectValueConverterSchemaEnable }}"
-            - name: CONNECT_INTERNAL_KEY_CONVERTER
-              value: {{ .Values.connectInternalKeyConverter }}
-            - name: CONNECT_INTERNAL_VALUE_CONVERTER
-              value: {{ .Values.connectInternalValueConverter }}
+            - name: KAFKA_HEAP_OPTS
+              value: "{{ .Values.heapOptions }}"
+            {{- range $key, $value := .Values.configurationOverrides }}
+            - name: {{ printf "CONNECT_%s" $key | replace "." "_" | upper | quote }}
+              value: {{ $value | quote }}
+            {{- end }}
+            {{- range $key, $value := .Values.customEnv }}
+            - name: {{ $key | quote }}
+              value: {{ $value | quote }}
+            {{- end }}
             {{- if .Values.jmx.port }}
             - name: KAFKA_JMX_PORT
               value: "{{ .Values.jmx.port }}"
             {{- end }}
+        {{- if .Values.customEnv.CUSTOM_SCRIPT_PATH }}
+          command:
+            - /bin/bash
+            - -c
+            - |
+              /etc/confluent/docker/run &
+              $CUSTOM_SCRIPT_PATH
+              sleep infinity
+          {{- if .Values.livenessProbe }}
+          livenessProbe:
+{{ toYaml .Values.livenessProbe | trim | indent 12 }}
+          {{- end }}
+        {{- end }}
+          {{- if .Values.volumeMounts }}
+          volumeMounts:
+{{ toYaml .Values.volumeMounts | indent 10 }}
+          {{- end}}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
       {{- end }}
       volumes:
+      {{- if .Values.volumes }}
+{{ toYaml .Values.volumes | trim | indent 6 }}
+      {{- end}}
       {{- if .Values.prometheus.jmx.enabled }}
       - name: jmx-config
         configMap:
           name: {{ template "cp-kafka-connect.fullname" . }}-jmx-configmap
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+{{ toYaml .Values.nodeSelector | indent 8 }}
+      {{- end }}
+      {{- if .Values.tolerations }}
+      tolerations:
+{{ toYaml .Values.tolerations | indent 8 }}
       {{- end }}

--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -32,6 +32,9 @@ spec:
         prometheus.io/port: {{ .Values.prometheus.jmx.port | quote }}
       {{- end }}
       {{- end }}
+      {{- if .Values.secrets }}
+        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+      {{- end }}
     spec:
       containers:
         {{- if .Values.prometheus.jmx.enabled }}
@@ -102,31 +105,38 @@ spec:
             - name: KAFKA_JMX_PORT
               value: "{{ .Values.jmx.port }}"
             {{- end }}
-        {{- if .Values.customEnv.CUSTOM_SCRIPT_PATH }}
+        {{- if .Values.runScripts }}
           command:
             - /bin/bash
             - -c
             - |
               /etc/confluent/docker/run &
-              $CUSTOM_SCRIPT_PATH
+              /tmp/scripts/*.sh
               sleep infinity
-          {{- if .Values.livenessProbe }}
-          livenessProbe:
-{{ toYaml .Values.livenessProbe | trim | indent 12 }}
-          {{- end }}
         {{- end }}
-          {{- if .Values.volumeMounts }}
+          livenessProbe:
+            httpGet:
+              path: /connectors
+              port: 8083
+            initialDelaySeconds: 30
+            periodSeconds: 5
+            failureThreshold: 10
+          {{- if .Values.configScripts }}
           volumeMounts:
-{{ toYaml .Values.volumeMounts | indent 10 }}
-          {{- end}}
+          - name: config-scripts
+            mountPath: /tmp/scripts/
+            readOnly: true
+          {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
       {{- end }}
       volumes:
-      {{- if .Values.volumes }}
-{{ toYaml .Values.volumes | trim | indent 6 }}
-      {{- end}}
+      {{- if .Values.configScripts }}
+      - name: config-scripts
+        configMap:
+          name: {{ template "cp-kafka-connect.fullname" . }}-config-scripts
+      {{- end }}
       {{- if .Values.prometheus.jmx.enabled }}
       - name: jmx-config
         configMap:

--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -32,8 +32,8 @@ spec:
         prometheus.io/port: {{ .Values.prometheus.jmx.port | quote }}
       {{- end }}
       {{- end }}
-      {{- if .Values.secrets }}
-        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+      {{- if .Values.configScripts }}
+        checksum/config-scripts: {{ include (print $.Template.BasePath "/config-scripts.yaml") . | sha256sum }}
       {{- end }}
     spec:
       containers:

--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -136,6 +136,7 @@ spec:
       - name: config-scripts
         configMap:
           name: {{ template "cp-kafka-connect.fullname" . }}-config-scripts
+          defaultMode: 777
       {{- end }}
       {{- if .Values.prometheus.jmx.enabled }}
       - name: jmx-config

--- a/charts/cp-kafka-connect/templates/secrets.yaml
+++ b/charts/cp-kafka-connect/templates/secrets.yaml
@@ -11,6 +11,6 @@ metadata:
 type: Opaque
 data:
   {{- range $key, $value := .Values.secrets }}
-  {{ $key }}: {{ $value | b64enc }}
+    {{ $key }}: {{ $value | b64enc }}
   {{- end }}
 {{- end }}

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -39,10 +39,12 @@ heapOptions: "-Xms512M -Xmx512M"
 
 ## Additional env variables
 ## CUSTOM_SCRIPT_PATH is the path of the custom shell script to be ran mounted in a volume
-customEnv: {}
+customEnv:
+  {}
   # CUSTOM_SCRIPT_PATH: /etc/scripts/create-connectors.sh
 
-resources: {}
+resources:
+  {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little
   # resources, such as Minikube. If you do want to specify resources, uncomment the following
@@ -96,36 +98,11 @@ kafka:
 ## e.g. gnoble-panther-cp-schema-registry:8081
 cp-schema-registry:
   url: ""
+## configScripts can be used to setup scripts
+## Do not forget to setup the scripToRun as well, you probably want to pull to make sure the service is up and running first
+# configScripts:
+#   list-connections.sh: |
+#     curl -X GET http://localhost:8083/connectors
 
-## List of volumeMounts for connect server container
-## ref: https://kubernetes.io/docs/concepts/storage/volumes/
-volumeMounts:
-# - name: credentials
-#   mountPath: /etc/creds-volume
-
-## List of volumeMounts for connect server container
-## ref: https://kubernetes.io/docs/concepts/storage/volumes/
-volumes:
-# - name: credentials
-#   secret:
-#     secretName: creds
-
-## Secret with multiple keys to serve the purpose of multiple secrets
-## Values for all the keys will be base64 encoded when the Secret is created or updated
-## ref: https://kubernetes.io/docs/concepts/configuration/secret/
-secrets:
-  # username: kafka123
-  # password: connect321
-
-## These values are used only when "customEnv.CUSTOM_SCRIPT_PATH" is defined.
-## "livenessProbe" is required only for the edge cases where the custom script to be ran takes too much time
-## and errors by the ENTRYPOINT are ignored by the container
-## As an example such a similar script is added to "cp-helm-charts/examples/create-connectors.sh"
-## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
-livenessProbe:
-  # httpGet:
-  #   path: /connectors
-  #   port: 8083
-  # initialDelaySeconds: 30
-  # periodSeconds: 5
-  # failureThreshold: 10
+## Can be used to run a scripts during startup
+runScripts: false

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -38,10 +38,7 @@ configurationOverrides:
 heapOptions: "-Xms512M -Xmx512M"
 
 ## Additional env variables
-## CUSTOM_SCRIPT_PATH is the path of the custom shell script to be ran mounted in a volume
-customEnv:
-  {}
-  # CUSTOM_SCRIPT_PATH: /etc/scripts/create-connectors.sh
+customEnv: {}
 
 resources:
   {}

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -7,7 +7,7 @@ replicaCount: 1
 ## Image Info
 ## ref: https://hub.docker.com/r/confluentinc/cp-kafka/
 image: confluentinc/cp-kafka-connect
-imageTag: 5.0.0
+imageTag: 5.5.0
 
 ## Specify a imagePullPolicy
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
@@ -20,15 +20,27 @@ imagePullSecrets:
 
 servicePort: 8083
 
-## Kafka Connect Worker Configurations
+## Kafka Connect properties
 ## ref: https://docs.confluent.io/current/connect/userguide.html#configuring-workers
-connectKeyConverter: "io.confluent.connect.avro.AvroConverter"
-connectValueConverter: "io.confluent.connect.avro.AvroConverter"
-connectKeyConverterSchemaEnable: true
-connectValueConverterSchemaEnable: true
-connectInternalKeyConverter: "org.apache.kafka.connect.json.JsonConverter"
-connectInternalValueConverter: "org.apache.kafka.connect.json.JsonConverter"
-pluginPath: "/usr/share/java"
+configurationOverrides:
+  "plugin.path": "/usr/share/java,/usr/share/confluent-hub-components"
+  "key.converter": "io.confluent.connect.avro.AvroConverter"
+  "value.converter": "io.confluent.connect.avro.AvroConverter"
+  "key.converter.schemas.enable": "false"
+  "value.converter.schemas.enable": "false"
+  "internal.key.converter": "org.apache.kafka.connect.json.JsonConverter"
+  "internal.value.converter": "org.apache.kafka.connect.json.JsonConverter"
+  "config.storage.replication.factor": "3"
+  "offset.storage.replication.factor": "3"
+  "status.storage.replication.factor": "3"
+
+## Kafka Connect JVM Heap Option
+heapOptions: "-Xms512M -Xmx512M"
+
+## Additional env variables
+## CUSTOM_SCRIPT_PATH is the path of the custom shell script to be ran mounted in a volume
+customEnv: {}
+  # CUSTOM_SCRIPT_PATH: /etc/scripts/create-connectors.sh
 
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
@@ -41,6 +53,17 @@ resources: {}
   # requests:
   #  cpu: 100m
   #  memory: 128Mi
+
+## Custom pod annotations
+podAnnotations: {}
+
+## Node labels for pod assignment
+## Ref: https://kubernetes.io/docs/concepts/configuration/assign-pod-node/
+nodeSelector: {}
+
+## Taints to tolerate on node assignment:
+## Ref: https://kubernetes.io/docs/concepts/configuration/taint-and-toleration/
+tolerations: []
 
 ## Monitoring
 ## Kafka Connect JMX Settings
@@ -57,7 +80,12 @@ prometheus:
     enabled: true
     image: solsson/kafka-prometheus-jmx-exporter@sha256
     imageTag: 6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143
+    imagePullPolicy: IfNotPresent
     port: 5556
+
+    ## Resources configuration for the JMX exporter container.
+    ## See the `resources` documentation above for details.
+    resources: {}
 
 ## You can list load balanced service endpoint, or list of all brokers (which is hard in K8s).  e.g.:
 ## bootstrapServers: "PLAINTEXT://dozing-prawn-kafka-headless:9092"
@@ -68,3 +96,36 @@ kafka:
 ## e.g. gnoble-panther-cp-schema-registry:8081
 cp-schema-registry:
   url: ""
+
+## List of volumeMounts for connect server container
+## ref: https://kubernetes.io/docs/concepts/storage/volumes/
+volumeMounts:
+# - name: credentials
+#   mountPath: /etc/creds-volume
+
+## List of volumeMounts for connect server container
+## ref: https://kubernetes.io/docs/concepts/storage/volumes/
+volumes:
+# - name: credentials
+#   secret:
+#     secretName: creds
+
+## Secret with multiple keys to serve the purpose of multiple secrets
+## Values for all the keys will be base64 encoded when the Secret is created or updated
+## ref: https://kubernetes.io/docs/concepts/configuration/secret/
+secrets:
+  # username: kafka123
+  # password: connect321
+
+## These values are used only when "customEnv.CUSTOM_SCRIPT_PATH" is defined.
+## "livenessProbe" is required only for the edge cases where the custom script to be ran takes too much time
+## and errors by the ENTRYPOINT are ignored by the container
+## As an example such a similar script is added to "cp-helm-charts/examples/create-connectors.sh"
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/
+livenessProbe:
+  # httpGet:
+  #   path: /connectors
+  #   port: 8083
+  # initialDelaySeconds: 30
+  # periodSeconds: 5
+  # failureThreshold: 10

--- a/examples/create-connectors.sh
+++ b/examples/create-connectors.sh
@@ -12,7 +12,9 @@ while :; do
     sleep 5
 done
 
-echo "======> Creating connectors"
+echo -e $(date) "Delete previous connector"
+curl -X DELETE http://localhost:8083/connectors/sample-connector
+echo -e $(date) "Create new connector"
 # Send a simple POST request to create the connector
 curl -X POST \
     -H "Content-Type: application/json" \
@@ -28,4 +30,5 @@ curl -X POST \
         "topic.prefix": "sample-connector-",
         "poll.interval.ms": 1000
         }
-    }' http://$CONNECT_REST_ADVERTISED_HOST_NAME:8083/connectors
+    }' http://localhost:8083/connectors
+echo -e $(date) "Done creating connector"


### PR DESCRIPTION
## What changes were proposed in this pull request?

This will remove the secrets approach and instead use the more commonly used config map to configure .sh scripts for running during the startup of the application. 

I chose to update the create-connectors.sh instead of copy pasting that in the values.yaml, mostly because it would add to much code, instead for the values.yaml i added a simple get connectors, so you can see it works

Striped out the volume and volume mounts and used a configScripts key to create the sh files that are if the key is configured, automatically are added to the deployement as volume and mounted, this way you only have to 'run' the scripts by enabling the runScripts flag

also added a default connectors liveness probe, really this can be always on since if that endpoint isn't working something is mis 
configured anyway

it took me a while before figuring out what the real bug was with the original code (with secrets) it was a simple tab, but i figured i would refactor it a bit to make it a lot more user friendly for the next person. 

## How was this patch tested?

helm upgrade on AKS system with the configs as default and some custom configs for creating a ES-sink