### PR TITLE
Fixed JMX_PORT env variable in Kafka REST Proxy

### DIFF
--- a/charts/cp-kafka-rest/templates/deployment.yaml
+++ b/charts/cp-kafka-rest/templates/deployment.yaml
@@ -89,7 +89,7 @@ spec:
             value: {{ $value | quote }}
           {{- end }}
           {{- if .Values.jmx.port }}
-          - name: KAFKA_REST_JMX_PORT
+          - name: JMX_PORT
             value: "{{ .Values.jmx.port }}"
           {{- end }}
       {{- if .Values.imagePullSecrets }}


### PR DESCRIPTION
The Kafka REST Proxy expects the parameter [JMX_PORT](https://github.com/confluentinc/kafka-rest/blob/master/bin/kafka-rest-run-class#L53), not KAFKAREST_JMX_PORT.

## What changes were proposed in this pull request?

I was experiencing [this issue](https://github.com/confluentinc/cp-helm-charts/issues/329) when trying to consume JMX metrics from the Kafka REST Proxy with the Prometheus exporter sidecar. Basically, when you try to consume the Prometheus metrics from the sidecar, a connectivity error happens, because that variable is not properly injected.

I used following versions of Kafka REST Proxy:

- v6.0.0
- v5.4.2

## How was this patch tested?

Tested with helm install at my company.
