### PR TITLE
Add possibility to set securityContext for Kafka and Zookeeper containers

### DIFF
--- a/charts/cp-kafka/templates/statefulset.yaml
+++ b/charts/cp-kafka/templates/statefulset.yaml
@@ -81,6 +81,9 @@ spec:
       - name: {{ template "cp-kafka.name" . }}-broker
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+        {{- if .Values.securityContext }}
+        securityContext: {{- toYaml .Values.securityContext | nindent 10 }}
+        {{- end }}
         ports:
         - containerPort: 9092
           name: kafka

--- a/charts/cp-kafka/values.yaml
+++ b/charts/cp-kafka/values.yaml
@@ -32,6 +32,13 @@ podManagementPolicy: OrderedReady
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
 updateStrategy: RollingUpdate
 
+# Security Context
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+# for Kafka container
+securityContext: {}
+  #  runAsUser: 1000
+  #  runAsGroup: 1000
+
 ## Kafka Server properties
 ## ref: https://kafka.apache.org/documentation/#configuration
 configurationOverrides:

--- a/charts/cp-zookeeper/templates/statefulset.yaml
+++ b/charts/cp-zookeeper/templates/statefulset.yaml
@@ -81,6 +81,9 @@ spec:
       - name: {{ template "cp-zookeeper.name" . }}-server
         image: "{{ .Values.image }}:{{ .Values.imageTag }}"
         imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+        {{- if .Values.securityContext }}
+        securityContext: {{- toYaml .Values.securityContext | nindent 10 }}
+        {{- end }}
         ports:
         - containerPort: {{ .Values.clientPort }}
           name: client

--- a/charts/cp-zookeeper/values.yaml
+++ b/charts/cp-zookeeper/values.yaml
@@ -21,7 +21,7 @@ imageTag: 5.5.0
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
 imagePullPolicy: IfNotPresent
 
-## Specify an array of imagePullSecrets. 
+## Specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.
 ## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
 imagePullSecrets:
@@ -34,6 +34,13 @@ podManagementPolicy: OrderedReady
 ## The StatefulSet Update Strategy which Zookeeper will use when changes are applied: OnDelete or RollingUpdate
 ## ref: https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#update-strategies
 updateStrategy: RollingUpdate
+
+# Security Context
+# ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+# for Zookeeper container
+securityContext: {}
+  #  runAsUser: 1000
+  #  runAsGroup: 1000
 
 ## Zookeeper Configuration
 ## ref: https://zookeeper.apache.org/doc/r3.4.10/zookeeperAdmin.html#sc_configuration


### PR DESCRIPTION
## What changes were proposed in this pull request?

Added possibility to include securityContext for Zookeeper and Kafka containers

## How was this patch tested?
* set 
  ```yaml
  cp-kafka:
    securityContext:
      runAsUser: 0
      runAsGroup: 0
  ```
  and 
  ```yaml
  cp-zookeeper:
    securityContext:
      runAsUser: 0
      runAsGroup: 0
  ```
  in `values.yaml`

* ```bash
  helm template kafka ./ > some.yaml
  ```
* find `securityContext` in `some.yaml`
* verified securityContext is set according to values in `values.yaml`