### PR TITLE
Add support for serviceAccount and podSecurity in cp-kafka-connect

### DIFF
--- a/charts/cp-kafka-connect/README.md
+++ b/charts/cp-kafka-connect/README.md
@@ -144,6 +144,15 @@ The configuration parameters in this section control the resources requested and
 | --------- | ----------- | ------- |
 | `podAnnotations` | Map of custom annotations to attach to the pod spec. | `{}` |
 
+### Security
+| Parameter | Description | Default |
+| --------- | ----------- | --------|
+| `serviceAccount.create` | If true, create the cp-kafka-connect service account | `true` |
+| `serviceAccount.name` | name of the cp-kafka-connect service account to use or create | `{{ cp-kafka-connect.fullname }}` |
+| `serviceAccount.annotations` | annotations for the cp-kafka-connect service account | `{}` |
+| `podSecurityContext` | podSecurityContext | `{}` |
+| `securityContext` | securityContext for containers in pod | `{}` |
+
 ### JMX Configuration
 
 | Parameter | Description | Default |

--- a/charts/cp-kafka-connect/templates/_helpers.tpl
+++ b/charts/cp-kafka-connect/templates/_helpers.tpl
@@ -79,3 +79,34 @@ Default GroupId to Release Name but allow it to be overridden
 {{- .Release.Name -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Common labels
+*/}}
+{{- define "cp-kafka-connect.labels" -}}
+helm.sh/chart: {{ include "cp-kafka-connect.chart" . }}
+{{ include "cp-kafka-connect.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "cp-kafka-connect.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "cp-kafka-connect.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "cp-kafka-connect.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "cp-kafka-connect.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -33,9 +33,15 @@ spec:
       {{- end }}
       {{- end }}
     spec:
+      serviceAccountName: {{ include "cp-kafka-connect.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+
       containers:
         {{- if .Values.prometheus.jmx.enabled }}
         - name: prometheus-jmx-exporter
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.prometheus.jmx.image }}:{{ .Values.prometheus.jmx.imageTag }}"
           imagePullPolicy: "{{ .Values.prometheus.jmx.imagePullPolicy }}"
           command:
@@ -57,6 +63,8 @@ spec:
             mountPath: /etc/jmx-kafka-connect
         {{- end }}
         - name: {{ template "cp-kafka-connect.name" . }}-server
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image }}:{{ .Values.imageTag }}"
           imagePullPolicy: "{{ .Values.imagePullPolicy }}"
           ports:

--- a/charts/cp-kafka-connect/templates/serviceaccount.yaml
+++ b/charts/cp-kafka-connect/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "cp-kafka-connect.serviceAccountName" . }}
+  labels:
+    {{- include "cp-kafka-connect.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -129,3 +129,23 @@ livenessProbe:
   # initialDelaySeconds: 30
   # periodSeconds: 5
   # failureThreshold: 10
+
+serviceAccount:
+  # Specifies whether a service account should be created
+  create: true
+  # Annotations to add to the service account
+  annotations: {}
+  # The name of the service account to use.
+  # If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podSecurityContext: {}
+  # fsGroup: 2000
+
+securityContext: {}
+  # capabilities:
+  #   drop:
+  #   - ALL
+  # readOnlyRootFilesystem: true
+  # runAsNonRoot: true
+  # runAsUser: 1000


### PR DESCRIPTION
## What changes were proposed in this pull request?

This change enables add serviceAccount and podSecurity to pod.

## How was this patch tested?

I deployed my fork in my cluster on AWS.
