### PR TITLE
fixed values.yaml

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -19,13 +19,14 @@ cp-zookeeper:
     ## Size for Data dir, where ZooKeeper will store the in-memory database snapshots.
     dataDirSize: 10Gi
     # dataDirStorageClass: ""
+    ## Size for data log dir, which is a dedicated log device to be used, and helps avoid competition between logging and snaphots.
+    dataLogDirSize: 10Gi
+    # dataLogDirStorageClass: ""
+    
   # TODO: find correct security context for user in this zk-image  
   securityContext: 
     runAsUser: 0
 
-    ## Size for data log dir, which is a dedicated log device to be used, and helps avoid competition between logging and snaphots.
-    dataLogDirSize: 10Gi
-    # dataLogDirStorageClass: ""
   resources: {}
   ## If you do want to specify resources, uncomment the following lines, adjust them as necessary,
   ## and remove the curly braces after 'resources:'


### PR DESCRIPTION
Simple fix for `values.yaml` file, since it had the property `dataLogDirSize`  in the wrong position (under `securityContext`), causing errors while installing it.
