### PR TITLE
[cp-schema-registry] Mounting volumes and env variables from secrets 

### DIFF
--- a/charts/cp-schema-registry/templates/deployment.yaml
+++ b/charts/cp-schema-registry/templates/deployment.yaml
@@ -69,6 +69,10 @@ spec:
             {{- end }}
           resources:
 {{ toYaml .Values.resources | indent 12 }}
+          {{- if .Values.volumeMounts }}
+          volumeMounts:
+{{ toYaml .Values.volumeMounts | indent 10 }}
+          {{- end}}
           env:
           - name: SCHEMA_REGISTRY_HOST_NAME
             valueFrom:
@@ -110,6 +114,9 @@ spec:
         configMap:
           name: {{ template "cp-schema-registry.fullname" . }}-jmx-configmap
       {{- end }}
+      {{- if .Values.volumes }}
+{{ toYaml .Values.volumes | trim | indent 6 }}
+      {{- end}}
       {{- if .Values.nodeSelector }}
       nodeSelector:
 {{ toYaml .Values.nodeSelector | indent 8 }}

--- a/charts/cp-schema-registry/templates/deployment.yaml
+++ b/charts/cp-schema-registry/templates/deployment.yaml
@@ -92,6 +92,11 @@ spec:
           - name: SCHEMA_REGISTRY_{{ $configName | replace "." "_" | upper }}
             value: {{ $configValue | quote }}
           {{ end }}
+          {{ range $configName, $configValue := .Values.configurationOverridesFromK8S }}
+          - name: SCHEMA_REGISTRY_{{ $configName | replace "." "_" | upper }}
+            valueFrom:
+{{- toYaml $configValue  | nindent 14 }}
+          {{ end }}
           {{- range $key, $value := .Values.customEnv }}
           - name: {{ $key | quote }}
             value: {{ $value | quote }}

--- a/charts/cp-schema-registry/values.yaml
+++ b/charts/cp-schema-registry/values.yaml
@@ -27,6 +27,14 @@ imagePullSecrets:
 ## Configuration Options can be found here: https://docs.confluent.io/current/schema-registry/docs/config.html
 configurationOverrides: {}
 
+## Schema Registry Settings Overrides
+## Can load values from secrets or configmap
+configurationOverridesFromK8S: {}
+  # kafkastore.ssl.truststore.password:
+  #   secretKeyRef:
+  #     name: name-of-secret
+  #     key: keyName
+
 ## Additional env variables
 customEnv: {}
 

--- a/charts/cp-schema-registry/values.yaml
+++ b/charts/cp-schema-registry/values.yaml
@@ -42,6 +42,19 @@ heapOptions: "-Xms512M -Xmx512M"
 kafka:
   bootstrapServers: ""
 
+## List of volumeMounts for schema-registry container
+## ref: https://kubernetes.io/docs/concepts/storage/volumes/
+volumeMounts:
+# - name: credentials
+#   mountPath: /etc/creds-volume
+
+## List of volumeMounts for schema-registry container
+## ref: https://kubernetes.io/docs/concepts/storage/volumes/
+volumes:
+# - name: credentials
+#   secret:
+#     secretName: creds
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allow mounting of volumes in schema-registry container  and defining configuration properties with a value from secrets 

## How was this patch tested?

helm install on AKS and connect to Kafka over SSL