### PR TITLE
Whitelist JMX broker topic metrics for all topics

### DIFF
--- a/charts/cp-kafka/templates/jmx-configmap.yaml
+++ b/charts/cp-kafka/templates/jmx-configmap.yaml
@@ -17,7 +17,7 @@ data:
     whitelistObjectNames:
     - kafka.server:type=ReplicaManager,name=*
     - kafka.controller:type=KafkaController,name=*
-    - kafka.server:type=BrokerTopicMetrics,name=*
+    - kafka.server:type=BrokerTopicMetrics,name=*,topic=*
     - kafka.network:type=RequestMetrics,name=RequestsPerSec,request=*
     - kafka.network:type=SocketServer,name=NetworkProcessorAvgIdlePercent
     - kafka.server:type=ReplicaFetcherManager,name=MaxLag,clientId=*


### PR DESCRIPTION
## What changes were proposed in this pull request?

The JMX exporter whitelist for broker metrics was slightly extended such that Prometheus now provides metrics such as `cp_kafka_server_brokertopicmetrics_messagesinpersec_topic_<my-topic>`. Such metrics were already available before #428 and are now brought back. See also the recent discussion on #461 for more information. 

## How was this patch tested?

Helm install in local Kubernetes Cluster. Topics metrics were displayed in Grafana using our [Theodolite Dashboard](https://github.com/cau-se/theodolite/blob/master/execution/infrastructure/grafana/dashboard-config-map.yaml).
