### PR TITLE
add SecurityContext and ServiceAccounts for containers, create SCC for ServiceAccounts

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -272,6 +272,55 @@ kafka-consumer-perf-test --broker-list $KAFKAS --messages 6000000 --threads 1 --
 ksqlDB is the streaming SQL engine that enables real-time data  processing against Apache Kafka.
 Now that you have running in your Kubernetes cluster, you may run a https://github.com/confluentinc/cp-helm-charts/blob/master/examples/ksql-demo.yaml[ksqlDB example].
 
+=== Openshift/OKD Pods and Containers execution policy
+
+By default, main components of this chart (Zookeeper and Kafka) execute
+as root with UID 0. It could be unacceptable for Kubernetes-based
+platforms using restrictions for your pods and containers execution like
+OpenShift/OKD.
+
+In OpenShift, you must define some objects for correct deploy:
+
+- `SecurityContextConstraint` `(SCC)` which allows you to execute
+containers with fixed GID and UID (1000). By default, you can execute
+something only in namespace-predefined random range of UIDs. `SCC`
+is cluster-wide object so you can have restricted access for it.
+- `serviceAccount` `(SA)` binded to `SCC`
+- `securityContext` for containers and, probably, pods: `runAsUser: UID`
+and `runAsGroup: GID`
+
+You *must* define these things for `Kafka`, `Zookeeper` and every other
+app which use fixed UID and RW access for volumes at the same time.
+
+Examples:
+
+```yaml
+cp-zookeeper:
+    serviceAccount:
+        create: true # will create serviceAccount with name based on release name and service name and bind it to container spec
+    securityContext: # will add securityCon
+        runAsUser: 1000
+        runAsGroup: 1000
+    securityContextConstraints:
+        create: true # will create SCC with name based on namespace name, release name and service name and bind serviceAccount to it by its name
+cp-kafka:
+    serviceAccount:
+        name: my-kafka-installation # will use existing SA
+    securityContext:
+        runAsUser: 1000
+        runAsGroup: 1000
+    securityContextConstraints:
+        create: true # will create SCC and bind existing SA to it
+        name: my-security-constraint # will use existing SCC
+cp-kafka-connect:
+    serviceAccount:
+        name: my-kafka-installation # will bind containers to existing SA which is manually binded to SCC. dont actually need because by default your containers will execute on predefined default SA with Restricted SCC (random UID range)
+    securityContext: # dont actually need because this service can be executed on random UID
+        runAsUser: 1000
+        runAsGroup: 1000
+    securityContextConstraints: {} # default value, will not create SCC
+```
+
 === Operations
 
 ==== Scaling Zookeeper

--- a/charts/cp-control-center/templates/deployment.yaml
+++ b/charts/cp-control-center/templates/deployment.yaml
@@ -32,11 +32,25 @@ spec:
         prometheus.io/port: {{ .Values.prometheus.jmx.port | quote }}
       {{- end }}
       {{- end }}
+    {{- if .Values.serviceAccount.name  }}
+      serviceAccount: {{ .Values.serviceAccount.name }}
+    {{- else  }}
+    {{- if .Values.serviceAccount.create }}
+      serviceAccount: {{ .Release.Name }}-cp-control-center
+    {{- end }}
+    {{- end  }}
+    {{- if .Values.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.podSecurityContext | indent 8 }}
+    {{- end }}
     spec:
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image }}:{{ .Values.imageTag }}"
           imagePullPolicy: {{ .Values.imagePullPolicy }}
+        {{- if .Values.securityContext }}
+          securityContext: {{- toYaml .Values.securityContext | nindent 10 }}
+        {{- end }}
           ports:
             - name: cc-http
               containerPort: {{ .Values.serviceHttpPort}}

--- a/charts/cp-control-center/templates/securitycontextconstraints.yml
+++ b/charts/cp-control-center/templates/securitycontextconstraints.yml
@@ -1,0 +1,56 @@
+{{ if .Values.serviceContextConstraints.create }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    kubernetes.io/description: "full copy of nonroot SecurityContextConstraints.
+    nonroot provides all features of the restricted SCC but allows users to run with any non-root UID.
+    The user must specify the UID or it must be specified on the by the manifest of the container runtime."
+    release.openshift.io/create-only: "true"
+{{ if .Values.serviceContextConstraints.name }}
+  name: {{ .Values.serviceContextConstraints.name }}
+{{ else }}
+  name: {{ .Namespace.Name }}-{{ .Release.Name }}-cp-control-center
+{{ end }}
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups: []
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - KILL
+  - MKNOD
+  - SETUID
+  - SETGID
+runAsUser:
+  type: MustRunAsNonRoot
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+{{ if .Values.serviceAccount.name }}
+  - system:serviceaccount:{{ .Release.Name }}:{{ if .Values.serviceAccount.name }}
+{{ else }}
+{{ if .Values.serviceAccount.create }}
+  - system:serviceaccount:{{ .Release.Name }}:{{ .Release.Name }}-cp-control-center
+{{ end }}
+{{ end }}
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - projected
+  - secret
+{{ end }}

--- a/charts/cp-control-center/templates/serviceaccount.yml
+++ b/charts/cp-control-center/templates/serviceaccount.yml
@@ -1,0 +1,11 @@
+{{ if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+{{ if .Values.serviceAccount.name }}
+  name: {{ .Values.serviceAccount.name }}
+{{ else }}
+  name: {{ .Release.Name }}-cp-control-center
+{{ end }}
+  namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/charts/cp-control-center/values.yaml
+++ b/charts/cp-control-center/values.yaml
@@ -13,6 +13,26 @@ imageTag: 6.0.1
 ## ref: http://kubernetes.io/docs/user-guide/images/#pre-pulling-images
 imagePullPolicy: IfNotPresent
 
+securityContext: {}
+  #  runAsUser: 1000
+  #  runAsGroup: 1000
+
+## securityContextConstraints. useful for OpenShift/OKD with default restricted securityContextConstraints
+securityContextConstraints: {}
+  # name: cp-control-center
+  # create: true
+
+## serviceAccount. useful for OpenShift/OKD with default restricted securityContextConstraints
+## if serviceAccount.create == true and securityContextConstraints == true it will add serviceAccount to SCC
+serviceAccount: {}
+  ## if create is true and name undefined will be created default SA == kafka
+  # name: cp-control-center
+  # create: true
+
+## podSecurityContext. useful for OpenShift/OKD with default restricted securityContextConstraints
+podSecurityContext: {}
+  # fsGroup: 1000
+
 ## Specify an array of imagePullSecrets.
 ## Secrets must be manually created in the namespace.
 ## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod

--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -32,12 +32,26 @@ spec:
         prometheus.io/port: {{ .Values.prometheus.jmx.port | quote }}
       {{- end }}
       {{- end }}
+    {{- if .Values.serviceAccount.name  }}
+      serviceAccount: {{ .Values.serviceAccount.name }}
+    {{- else  }}
+    {{- if .Values.serviceAccount.create }}
+      serviceAccount: {{ .Release.Name }}-cp-kafka-connect
+    {{- end }}
+    {{- end  }}
+    {{- if .Values.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.podSecurityContext | indent 8 }}
+    {{- end }}
     spec:
       containers:
         {{- if .Values.prometheus.jmx.enabled }}
         - name: prometheus-jmx-exporter
           image: "{{ .Values.prometheus.jmx.image }}:{{ .Values.prometheus.jmx.imageTag }}"
           imagePullPolicy: "{{ .Values.prometheus.jmx.imagePullPolicy }}"
+        {{- if .Values.securityContext }}
+          securityContext: {{- toYaml .Values.securityContext | nindent 10 }}
+        {{- end }}
           command:
           - java
           - -XX:+UnlockExperimentalVMOptions
@@ -59,6 +73,9 @@ spec:
         - name: {{ template "cp-kafka-connect.name" . }}-server
           image: "{{ .Values.image }}:{{ .Values.imageTag }}"
           imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+        {{- if .Values.securityContext }}
+          securityContext: {{- toYaml .Values.securityContext | nindent 10 }}
+        {{- end }}
           ports:
             - name: kafka-connect
               containerPort: {{ .Values.servicePort}}

--- a/charts/cp-kafka-connect/templates/securitycontextconstraints.yml
+++ b/charts/cp-kafka-connect/templates/securitycontextconstraints.yml
@@ -1,0 +1,56 @@
+{{ if .Values.serviceContextConstraints.create }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    kubernetes.io/description: "full copy of nonroot SecurityContextConstraints.
+    nonroot provides all features of the restricted SCC but allows users to run with any non-root UID.
+    The user must specify the UID or it must be specified on the by the manifest of the container runtime."
+    release.openshift.io/create-only: "true"
+{{ if .Values.serviceContextConstraints.name }}
+  name: {{ .Values.serviceContextConstraints.name }}
+{{ else }}
+  name: {{ .Namespace.Name }}-{{ .Release.Name }}-cp-kafka-connect
+{{ end }}
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups: []
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - KILL
+  - MKNOD
+  - SETUID
+  - SETGID
+runAsUser:
+  type: MustRunAsNonRoot
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+{{ if .Values.serviceAccount.name }}
+  - system:serviceaccount:{{ .Release.Name }}:{{ if .Values.serviceAccount.name }}
+{{ else }}
+{{ if .Values.serviceAccount.create }}
+  - system:serviceaccount:{{ .Release.Name }}:{{ .Release.Name }}-cp-kafka-connect
+{{ end }}
+{{ end }}
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - projected
+  - secret
+{{ end }}

--- a/charts/cp-kafka-connect/templates/serviceaccount.yml
+++ b/charts/cp-kafka-connect/templates/serviceaccount.yml
@@ -1,0 +1,11 @@
+{{ if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+{{ if .Values.serviceAccount.name }}
+  name: {{ .Values.serviceAccount.name }}
+{{ else }}
+  name: {{ .Release.Name }}-cp-kafka-connect
+{{ end }}
+  namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -18,6 +18,26 @@ imagePullPolicy: IfNotPresent
 ## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
 imagePullSecrets:
 
+securityContext: {}
+  #  runAsUser: 1000
+  #  runAsGroup: 1000
+
+## securityContextConstraints. useful for OpenShift/OKD with default restricted securityContextConstraints
+securityContextConstraints: {}
+  # name: cp-kafka-connect
+  # create: true
+
+## serviceAccount. useful for OpenShift/OKD with default restricted securityContextConstraints
+## if serviceAccount.create == true and securityContextConstraints == true it will add serviceAccount to SCC
+serviceAccount: {}
+  ## if create is true and name undefined will be created default SA == kafka
+  # name: cp-kafka-connect
+  # create: true
+
+## podSecurityContext. useful for OpenShift/OKD with default restricted securityContextConstraints
+podSecurityContext: {}
+  # fsGroup: 1000
+
 servicePort: 8083
 
 ## Kafka Connect properties

--- a/charts/cp-kafka-rest/templates/deployment.yaml
+++ b/charts/cp-kafka-rest/templates/deployment.yaml
@@ -32,12 +32,26 @@ spec:
         prometheus.io/port: {{ .Values.prometheus.jmx.port | quote }}
       {{- end }}
       {{- end }}
+    {{- if .Values.serviceAccount.name  }}
+      serviceAccount: {{ .Values.serviceAccount.name }}
+    {{- else  }}
+    {{- if .Values.serviceAccount.create }}
+      serviceAccount: {{ .Release.Name }}-cp-kafka-rest
+    {{- end }}
+    {{- end  }}
+    {{- if .Values.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.podSecurityContext | indent 8 }}
+    {{- end }}
     spec:
       containers:
         {{- if .Values.prometheus.jmx.enabled }}
         - name: prometheus-jmx-exporter
           image: "{{ .Values.prometheus.jmx.image }}:{{ .Values.prometheus.jmx.imageTag }}"
           imagePullPolicy: "{{ .Values.prometheus.jmx.imagePullPolicy }}"
+        {{- if .Values.securityContext }}
+          securityContext: {{- toYaml .Values.securityContext | nindent 10 }}
+        {{- end }}
           command:
           - java
           - -XX:+UnlockExperimentalVMOptions
@@ -59,6 +73,9 @@ spec:
         - name: {{ template "cp-kafka-rest.name" . }}-server
           image: "{{ .Values.image }}:{{ .Values.imageTag }}"
           imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+        {{- if .Values.securityContext }}
+          securityContext: {{- toYaml .Values.securityContext | nindent 10 }}
+        {{- end }}
           ports:
             - name: rest-proxy
               containerPort: {{ .Values.servicePort}}

--- a/charts/cp-kafka-rest/templates/securitycontextconstraints.yml
+++ b/charts/cp-kafka-rest/templates/securitycontextconstraints.yml
@@ -1,0 +1,56 @@
+{{ if .Values.serviceContextConstraints.create }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    kubernetes.io/description: "full copy of nonroot SecurityContextConstraints.
+    nonroot provides all features of the restricted SCC but allows users to run with any non-root UID.
+    The user must specify the UID or it must be specified on the by the manifest of the container runtime."
+    release.openshift.io/create-only: "true"
+{{ if .Values.serviceContextConstraints.name }}
+  name: {{ .Values.serviceContextConstraints.name }}
+{{ else }}
+  name: {{ .Namespace.Name }}-{{ .Release.Name }}-cp-kafka-rest
+{{ end }}
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups: []
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - KILL
+  - MKNOD
+  - SETUID
+  - SETGID
+runAsUser:
+  type: MustRunAsNonRoot
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+{{ if .Values.serviceAccount.name }}
+  - system:serviceaccount:{{ .Release.Name }}:{{ if .Values.serviceAccount.name }}
+{{ else }}
+{{ if .Values.serviceAccount.create }}
+  - system:serviceaccount:{{ .Release.Name }}:{{ .Release.Name }}-cp-kafka-rest
+{{ end }}
+{{ end }}
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - projected
+  - secret
+{{ end }}

--- a/charts/cp-kafka-rest/templates/serviceaccount.yml
+++ b/charts/cp-kafka-rest/templates/serviceaccount.yml
@@ -1,0 +1,11 @@
+{{ if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+{{ if .Values.serviceAccount.name }}
+  name: {{ .Values.serviceAccount.name }}
+{{ else }}
+  name: {{ .Release.Name }}-cp-kafka-rest
+{{ end }}
+  namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/charts/cp-kafka-rest/values.yaml
+++ b/charts/cp-kafka-rest/values.yaml
@@ -18,6 +18,26 @@ imagePullPolicy: IfNotPresent
 ## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
 imagePullSecrets:
 
+securityContext: {}
+  #  runAsUser: 1000
+  #  runAsGroup: 1000
+
+## securityContextConstraints. useful for OpenShift/OKD with default restricted securityContextConstraints
+securityContextConstraints: {}
+  # name: zookeeper
+  # create: true
+
+## serviceAccount. useful for OpenShift/OKD with default restricted securityContextConstraints
+## if serviceAccount.create == true and securityContextConstraints == true it will add serviceAccount to SCC
+serviceAccount: {}
+  ## if create is true and name undefined will be created default SA == kafka
+  # name: zookeeper
+  # create: true
+
+## podSecurityContext. useful for OpenShift/OKD with default restricted securityContextConstraints
+podSecurityContext: {}
+  # fsGroup: 1000
+
 servicePort: 8082
 
 ## Kafka rest JVM Heap Option

--- a/charts/cp-kafka/templates/securitycontextconstraints.yml
+++ b/charts/cp-kafka/templates/securitycontextconstraints.yml
@@ -1,0 +1,56 @@
+{{ if .Values.serviceContextConstraints.create }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    kubernetes.io/description: "full copy of nonroot SecurityContextConstraints.
+    nonroot provides all features of the restricted SCC but allows users to run with any non-root UID.
+    The user must specify the UID or it must be specified on the by the manifest of the container runtime."
+    release.openshift.io/create-only: "true"
+{{ if .Values.serviceContextConstraints.name }}
+  name: {{ .Values.serviceContextConstraints.name }}
+{{ else }}
+  name: {{ .Namespace.Name }}-{{ .Release.Name }}-kafka
+{{ end }}
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups: []
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - KILL
+  - MKNOD
+  - SETUID
+  - SETGID
+runAsUser:
+  type: MustRunAsNonRoot
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+{{ if .Values.serviceAccount.name }}
+  - system:serviceaccount:{{ .Release.Name }}:{{ if .Values.serviceAccount.name }}
+{{ else }}
+{{ if .Values.serviceAccount.create }}
+  - system:serviceaccount:{{ .Release.Name }}:{{ .Release.Name }}-kafka
+{{ end }}
+{{ end }}
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - projected
+  - secret
+{{ end }}

--- a/charts/cp-kafka/templates/serviceaccount.yml
+++ b/charts/cp-kafka/templates/serviceaccount.yml
@@ -1,0 +1,11 @@
+{{ if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+{{ if .Values.serviceAccount.name }}
+  name: {{ .Values.serviceAccount.name }}
+{{ else }}
+  name: {{ .Release.Name }}-kafka
+{{ end }}
+  namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/charts/cp-kafka/templates/statefulset.yaml
+++ b/charts/cp-kafka/templates/statefulset.yaml
@@ -39,6 +39,17 @@ spec:
       {{- end }}
       {{- end }}
     spec:
+    {{- if .Values.serviceAccount.name  }}
+      serviceAccount: {{ .Values.serviceAccount.name }}
+    {{- else  }}
+    {{- if .Values.serviceAccount.create }}
+      serviceAccount: {{ .Release.Name }}-kafka
+    {{- end }}
+    {{- end  }}
+    {{- if .Values.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.podSecurityContext | indent 8 }}
+    {{- end }}
       affinity:
       {{- if .Values.affinity }}
 {{ toYaml .Values.affinity | indent 8 }}
@@ -64,6 +75,9 @@ spec:
       - name: prometheus-jmx-exporter
         image: "{{ .Values.prometheus.jmx.image }}:{{ .Values.prometheus.jmx.imageTag }}"
         imagePullPolicy: "{{ .Values.prometheus.jmx.imagePullPolicy }}"
+        {{- if .Values.securityContext }}
+        securityContext: {{- toYaml .Values.securityContext | nindent 10 }}
+        {{- end }}
         command:
         - java
         - -XX:+UnlockExperimentalVMOptions

--- a/charts/cp-kafka/values.yaml
+++ b/charts/cp-kafka/values.yaml
@@ -39,6 +39,26 @@ securityContext: {}
   #  runAsUser: 1000
   #  runAsGroup: 1000
 
+securityContext: {}
+  #  runAsUser: 1000
+  #  runAsGroup: 1000
+
+## securityContextConstraints. useful for OpenShift/OKD with default restricted securityContextConstraints
+securityContextConstraints: {}
+  # name: kafka
+  # create: true
+
+## serviceAccount. useful for OpenShift/OKD with default restricted securityContextConstraints
+## if serviceAccount.create == true and securityContextConstraints == true it will add serviceAccount to SCC
+serviceAccount: {}
+  ## if create is true and name undefined will be created default SA == kafka
+  # name: kafka
+  # create: true
+
+## podSecurityContext. useful for OpenShift/OKD with default restricted securityContextConstraints
+podSecurityContext: {}
+  # fsGroup: 1000
+
 ## Kafka Server properties
 ## ref: https://kafka.apache.org/documentation/#configuration
 configurationOverrides:

--- a/charts/cp-ksql-server/templates/deployment.yaml
+++ b/charts/cp-ksql-server/templates/deployment.yaml
@@ -32,12 +32,26 @@ spec:
         prometheus.io/port: {{ .Values.prometheus.jmx.port | quote }}
       {{- end }}
       {{- end }}
+    {{- if .Values.serviceAccount.name  }}
+      serviceAccount: {{ .Values.serviceAccount.name }}
+    {{- else  }}
+    {{- if .Values.serviceAccount.create }}
+      serviceAccount: {{ .Release.Name }}-cp-ksql-server
+    {{- end }}
+    {{- end  }}
+    {{- if .Values.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.podSecurityContext | indent 8 }}
+    {{- end }}
     spec:
       containers:
         {{- if .Values.prometheus.jmx.enabled }}
         - name: prometheus-jmx-exporter
           image: "{{ .Values.prometheus.jmx.image }}:{{ .Values.prometheus.jmx.imageTag }}"
           imagePullPolicy: "{{ .Values.prometheus.jmx.imagePullPolicy }}"
+        {{- if .Values.securityContext }}
+          securityContext: {{- toYaml .Values.securityContext | nindent 10 }}
+        {{- end }}
           command:
           - java
           - -XX:+UnlockExperimentalVMOptions
@@ -59,6 +73,9 @@ spec:
         - name: {{ template "cp-ksql-server.name" . }}
           image: "{{ .Values.image }}:{{ .Values.imageTag }}"
           imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+        {{- if .Values.securityContext }}
+          securityContext: {{- toYaml .Values.securityContext | nindent 10 }}
+        {{- end }}
           ports:
             - name: server
               containerPort: {{ .Values.servicePort}}

--- a/charts/cp-ksql-server/templates/securitycontextconstraints.yml
+++ b/charts/cp-ksql-server/templates/securitycontextconstraints.yml
@@ -1,0 +1,56 @@
+{{ if .Values.serviceContextConstraints.create }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    kubernetes.io/description: "full copy of nonroot SecurityContextConstraints.
+    nonroot provides all features of the restricted SCC but allows users to run with any non-root UID.
+    The user must specify the UID or it must be specified on the by the manifest of the container runtime."
+    release.openshift.io/create-only: "true"
+{{ if .Values.serviceContextConstraints.name }}
+  name: {{ .Values.serviceContextConstraints.name }}
+{{ else }}
+  name: {{ .Namespace.Name }}-{{ .Release.Name }}-cp-ksql-server
+{{ end }}
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups: []
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - KILL
+  - MKNOD
+  - SETUID
+  - SETGID
+runAsUser:
+  type: MustRunAsNonRoot
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+{{ if .Values.serviceAccount.name }}
+  - system:serviceaccount:{{ .Release.Name }}:{{ if .Values.serviceAccount.name }}
+{{ else }}
+{{ if .Values.serviceAccount.create }}
+  - system:serviceaccount:{{ .Release.Name }}:{{ .Release.Name }}-cp-ksql-server
+{{ end }}
+{{ end }}
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - projected
+  - secret
+{{ end }}

--- a/charts/cp-ksql-server/templates/serviceaccount.yml
+++ b/charts/cp-ksql-server/templates/serviceaccount.yml
@@ -1,0 +1,11 @@
+{{ if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+{{ if .Values.serviceAccount.name }}
+  name: {{ .Values.serviceAccount.name }}
+{{ else }}
+  name: {{ .Release.Name }}-cp-ksql-server
+{{ end }}
+  namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/charts/cp-ksql-server/values.yaml
+++ b/charts/cp-ksql-server/values.yaml
@@ -18,6 +18,26 @@ imagePullPolicy: IfNotPresent
 ## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
 imagePullSecrets:
 
+securityContext: {}
+  #  runAsUser: 1000
+  #  runAsGroup: 1000
+
+## securityContextConstraints. useful for OpenShift/OKD with default restricted securityContextConstraints
+securityContextConstraints: {}
+  # name: zookeeper
+  # create: true
+
+## serviceAccount. useful for OpenShift/OKD with default restricted securityContextConstraints
+## if serviceAccount.create == true and securityContextConstraints == true it will add serviceAccount to SCC
+serviceAccount: {}
+  ## if create is true and name undefined will be created default SA == kafka
+  # name: zookeeper
+  # create: true
+
+## podSecurityContext. useful for OpenShift/OKD with default restricted securityContextConstraints
+podSecurityContext: {}
+  # fsGroup: 1000
+
 servicePort: 8088
 
 ## KSQL JVM Heap Option

--- a/charts/cp-schema-registry/templates/deployment.yaml
+++ b/charts/cp-schema-registry/templates/deployment.yaml
@@ -32,12 +32,26 @@ spec:
         prometheus.io/port: {{ .Values.prometheus.jmx.port | quote }}
       {{- end }}
       {{- end }}
+    {{- if .Values.serviceAccount.name  }}
+      serviceAccount: {{ .Values.serviceAccount.name }}
+    {{- else  }}
+    {{- if .Values.serviceAccount.create }}
+      serviceAccount: {{ .Release.Name }}-cp-schema-registry
+    {{- end }}
+    {{- end  }}
+    {{- if .Values.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.podSecurityContext | indent 8 }}
+    {{- end }}
     spec:
       containers:
         {{- if .Values.prometheus.jmx.enabled }}
         - name: prometheus-jmx-exporter
           image: "{{ .Values.prometheus.jmx.image }}:{{ .Values.prometheus.jmx.imageTag }}"
           imagePullPolicy: "{{ .Values.prometheus.jmx.imagePullPolicy }}"
+        {{- if .Values.securityContext }}
+          securityContext: {{- toYaml .Values.securityContext | nindent 10 }}
+        {{- end }}
           command:
           - java
           - -XX:+UnlockExperimentalVMOptions
@@ -59,6 +73,9 @@ spec:
         - name: {{ template "cp-schema-registry.name" . }}-server
           image: "{{ .Values.image }}:{{ .Values.imageTag }}"
           imagePullPolicy: "{{ .Values.imagePullPolicy }}"
+        {{- if .Values.securityContext }}
+          securityContext: {{- toYaml .Values.securityContext | nindent 10 }}
+        {{- end }}
           ports:
             - name: schema-registry
               containerPort: {{ .Values.servicePort }}

--- a/charts/cp-schema-registry/templates/securitycontextconstraints.yml
+++ b/charts/cp-schema-registry/templates/securitycontextconstraints.yml
@@ -1,0 +1,56 @@
+{{ if .Values.serviceContextConstraints.create }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    kubernetes.io/description: "full copy of nonroot SecurityContextConstraints.
+    nonroot provides all features of the restricted SCC but allows users to run with any non-root UID.
+    The user must specify the UID or it must be specified on the by the manifest of the container runtime."
+    release.openshift.io/create-only: "true"
+{{ if .Values.serviceContextConstraints.name }}
+  name: {{ .Values.serviceContextConstraints.name }}
+{{ else }}
+  name: {{ .Namespace.Name }}-{{ .Release.Name }}-cp-schema-registry
+{{ end }}
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups: []
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - KILL
+  - MKNOD
+  - SETUID
+  - SETGID
+runAsUser:
+  type: MustRunAsNonRoot
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+{{ if .Values.serviceAccount.name }}
+  - system:serviceaccount:{{ .Release.Name }}:{{ if .Values.serviceAccount.name }}
+{{ else }}
+{{ if .Values.serviceAccount.create }}
+  - system:serviceaccount:{{ .Release.Name }}:{{ .Release.Name }}-cp-schema-registry
+{{ end }}
+{{ end }}
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - projected
+  - secret
+{{ end }}

--- a/charts/cp-schema-registry/templates/serviceaccount.yml
+++ b/charts/cp-schema-registry/templates/serviceaccount.yml
@@ -1,0 +1,11 @@
+{{ if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+{{ if .Values.serviceAccount.name }}
+  name: {{ .Values.serviceAccount.name }}
+{{ else }}
+  name: {{ .Release.Name }}-cp-schema-registry
+{{ end }}
+  namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/charts/cp-schema-registry/values.yaml
+++ b/charts/cp-schema-registry/values.yaml
@@ -23,6 +23,26 @@ imagePullPolicy: IfNotPresent
 ## ref: https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
 imagePullSecrets:
 
+securityContext: {}
+  #  runAsUser: 1000
+  #  runAsGroup: 1000
+
+## securityContextConstraints. useful for OpenShift/OKD with default restricted securityContextConstraints
+securityContextConstraints: {}
+  # name: zookeeper
+  # create: true
+
+## serviceAccount. useful for OpenShift/OKD with default restricted securityContextConstraints
+## if serviceAccount.create == true and securityContextConstraints == true it will add serviceAccount to SCC
+serviceAccount: {}
+  ## if create is true and name undefined will be created default SA == kafka
+  # name: zookeeper
+  # create: true
+
+## podSecurityContext. useful for OpenShift/OKD with default restricted securityContextConstraints
+podSecurityContext: {}
+  # fsGroup: 1000
+
 ## Schema Registry Settings Overrides
 ## Configuration Options can be found here: https://docs.confluent.io/current/schema-registry/docs/config.html
 configurationOverrides: {}

--- a/charts/cp-zookeeper/templates/securitycontextconstraints.yml
+++ b/charts/cp-zookeeper/templates/securitycontextconstraints.yml
@@ -1,0 +1,56 @@
+{{ if .Values.serviceContextConstraints.create }}
+apiVersion: security.openshift.io/v1
+kind: SecurityContextConstraints
+metadata:
+  annotations:
+    include.release.openshift.io/self-managed-high-availability: "true"
+    kubernetes.io/description: "full copy of nonroot SecurityContextConstraints.
+    nonroot provides all features of the restricted SCC but allows users to run with any non-root UID.
+    The user must specify the UID or it must be specified on the by the manifest of the container runtime."
+    release.openshift.io/create-only: "true"
+{{ if .Values.serviceContextConstraints.name }}
+  name: {{ .Values.serviceContextConstraints.name }}
+{{ else }}
+  name: {{ .Namespace.Name }}-{{ .Release.Name }}-zookeeper
+{{ end }}
+allowHostDirVolumePlugin: false
+allowHostIPC: false
+allowHostNetwork: false
+allowHostPID: false
+allowHostPorts: false
+allowPrivilegeEscalation: true
+allowPrivilegedContainer: false
+allowedCapabilities: null
+defaultAddCapabilities: null
+fsGroup:
+  type: RunAsAny
+groups: []
+priority: null
+readOnlyRootFilesystem: false
+requiredDropCapabilities:
+  - KILL
+  - MKNOD
+  - SETUID
+  - SETGID
+runAsUser:
+  type: MustRunAsNonRoot
+seLinuxContext:
+  type: MustRunAs
+supplementalGroups:
+  type: RunAsAny
+users:
+{{ if .Values.serviceAccount.name }}
+  - system:serviceaccount:{{ .Release.Name }}:{{ if .Values.serviceAccount.name }}
+{{ else }}
+{{ if .Values.serviceAccount.create }}
+  - system:serviceaccount:{{ .Release.Name }}:{{ .Release.Name }}-zookeeper
+{{ end }}
+{{ end }}
+volumes:
+  - configMap
+  - downwardAPI
+  - emptyDir
+  - persistentVolumeClaim
+  - projected
+  - secret
+{{ end }}

--- a/charts/cp-zookeeper/templates/serviceaccount.yml
+++ b/charts/cp-zookeeper/templates/serviceaccount.yml
@@ -1,0 +1,11 @@
+{{ if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+{{ if .Values.serviceAccount.name }}
+  name: {{ .Values.serviceAccount.name }}
+{{ else }}
+  name: {{ .Release.Name }}-zookeeper
+{{ end }}
+  namespace: {{ .Release.Namespace }}
+{{ end }}

--- a/charts/cp-zookeeper/templates/statefulset.yaml
+++ b/charts/cp-zookeeper/templates/statefulset.yaml
@@ -39,6 +39,17 @@ spec:
       {{- end }}
       {{- end }}
     spec:
+    {{- if .Values.serviceAccount.name  }}
+      serviceAccount: {{ .Values.serviceAccount.name }}
+    {{- else  }}
+    {{- if .Values.serviceAccount.create }}
+      serviceAccount: {{ .Release.Name }}-zookeeper
+    {{- end }}
+    {{- end  }}
+    {{- if .Values.podSecurityContext }}
+      securityContext:
+{{ toYaml .Values.podSecurityContext | indent 8 }}
+    {{- end }}
       affinity:
       {{- if .Values.affinity }}
 {{ toYaml .Values.affinity | indent 8 }}
@@ -64,6 +75,9 @@ spec:
       - name: prometheus-jmx-exporter
         image: "{{ .Values.prometheus.jmx.image }}:{{ .Values.prometheus.jmx.imageTag }}"
         imagePullPolicy: "{{ .Values.prometheus.jmx.imagePullPolicy }}"
+        {{- if .Values.securityContext }}
+        securityContext: {{- toYaml .Values.securityContext | nindent 10 }}
+        {{- end }}
         command:
         - java
         - -XX:+UnlockExperimentalVMOptions

--- a/charts/cp-zookeeper/values.yaml
+++ b/charts/cp-zookeeper/values.yaml
@@ -42,6 +42,22 @@ securityContext: {}
   #  runAsUser: 1000
   #  runAsGroup: 1000
 
+## securityContextConstraints. useful for OpenShift/OKD with default restricted securityContextConstraints
+securityContextConstraints: {}
+  # name: zookeeper
+  # create: true
+
+## serviceAccount. useful for OpenShift/OKD with default restricted securityContextConstraints
+## if serviceAccount.create == true and securityContextConstraints == true it will add serviceAccount to SCC
+serviceAccount: {}
+  ## if create is true and name undefined will be created default SA == kafka
+  # name: zookeeper
+  # create: true
+
+## podSecurityContext. useful for OpenShift/OKD with default restricted securityContextConstraints
+podSecurityContext: {}
+  # fsGroup: 1000
+
 ## Zookeeper Configuration
 ## ref: https://zookeeper.apache.org/doc/r3.4.10/zookeeperAdmin.html#sc_configuration
 ## ref: https://docs.confluent.io/current/zookeeper/deployment.html#important-configuration-options

--- a/values.yaml
+++ b/values.yaml
@@ -23,9 +23,13 @@ cp-zookeeper:
     dataLogDirSize: 10Gi
     # dataLogDirStorageClass: ""
     
-  # TODO: find correct security context for user in this zk-image  
-  securityContext: 
+  #podsecurityContext:
+  #  fsGroup: 1000
+  securityContext:
     runAsUser: 0
+  #  runAsGroup: 1000
+  #serviceAccount:
+  #  create: true
 
   resources: {}
   ## If you do want to specify resources, uncomment the following lines, adjust them as necessary,
@@ -64,8 +68,13 @@ cp-kafka:
   #  requests:
   #   cpu: 100m
   #   memory: 128Mi
-  securityContext: 
+  #podSecurityContext:
+  #  fsGroup: 1000
+  securityContext:
     runAsUser: 0
+  #  runAsGroup: 1000
+  #serviceAccount:
+  #  create: true
 
 ## ------------------------------------------------------
 ## Schema Registry


### PR DESCRIPTION
## What changes were proposed in this pull request?

- add SecurityContext customization for JMX-exporter containers and all main services
- add SecurityContext customization for pods
- add ServiceAccount customization for pods
- add generation of ServiceAccounts for every chart
- add generation of SecurityConstraintContext and binding it to your ServiceAccounts
- extend ReadMe

## How was this patch tested?
helm install on Azure managed OKD and Kubernetes in different configurations
