### PR TITLE
Fix timeout in Helm test

### DIFF
--- a/charts/cp-kafka/templates/tests/canary-pod.yaml
+++ b/charts/cp-kafka/templates/tests/canary-pod.yaml
@@ -23,5 +23,5 @@ spec:
       # Produce a test message to the topic
       echo "$MESSAGE" | kafka-console-producer --broker-list {{ template "cp-kafka.fullname" . }}:9092 --topic {{ template "cp-kafka.fullname" . }}-canary-topic && \
       # Consume a test message from the topic
-      kafka-console-consumer --bootstrap-server {{ template "cp-kafka.fullname" . }}-headless:9092 --topic {{ template "cp-kafka.fullname" . }}-canary-topic --from-beginning --timeout-ms 2000 | grep "$MESSAGE"
+      kafka-console-consumer --bootstrap-server {{ template "cp-kafka.fullname" . }}-headless:9092 --topic {{ template "cp-kafka.fullname" . }}-canary-topic --from-beginning --max-messages 1 --timeout-ms 30000 | grep "$MESSAGE"
   restartPolicy: Never


### PR DESCRIPTION
## What changes were proposed in this pull request?

As presented in #318, `helm test` fails in certain configurations (see below) due to a timeout. Instead of waiting for some time and then check whether messages have been consumed, this fix waits for exactly one message to be consumed. Additionally, a timeout of 30s is set to not wait forever in case of a failing test.

## How was this patch tested?

This fix was tested in a local Kubernetes cluster with `helm install`. We use 12 Kafka brokers and without this fix, `helm test` fails; with this test, it succeeds.

Kubernetes cluster config: version 1.18, 5 nodes, each having 2 Intel Xeon Gold 6130 (2.1 GHz, 16 Cores) with 384 GB memory.
