### PR TITLE
Add kafka-connect url to ksqldb

### DIFF
--- a/charts/cp-ksql-server/templates/_helpers.tpl
+++ b/charts/cp-ksql-server/templates/_helpers.tpl
@@ -79,3 +79,20 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 {{- printf "http://%s:8081" (include "cp-ksql-server.cp-schema-registry.fullname" .) -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create a default fully qualified kafka connect name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+*/}}
+{{- define "cp-ksql-server.cp-kafka-connect.fullname" -}}
+{{- $name := default "cp-kafka-connect" (index .Values "cp-kafka-connect" "nameOverride") -}}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{- define "cp-ksql-server.cp-kafka-connect.service-name" -}}
+{{- if (index .Values "cp-kafka-connect" "url") -}}
+{{- printf "%s" (index .Values "cp-kafka-connect" "url") -}}
+{{- else -}}
+{{- printf "http://%s:8083" (include "cp-ksql-server.cp-kafka-connect.fullname" .) -}}
+{{- end -}}
+{{- end -}}

--- a/charts/cp-ksql-server/templates/deployment.yaml
+++ b/charts/cp-ksql-server/templates/deployment.yaml
@@ -81,6 +81,8 @@ spec:
             value: {{ template "cp-ksql-server.serviceId" . }}
           - name: KSQL_KSQL_SCHEMA_REGISTRY_URL
             value: {{ template "cp-ksql-server.cp-schema-registry.service-name" . }}
+          - name: KSQL_KSQL_CONNECT_URL
+            value: {{ template "cp-ksql-server.cp-kafka-connect.service-name" . }}
           - name: KSQL_HEAP_OPTS
             value: "{{ .Values.heapOptions }}"
           {{- if .Values.ksql.headless }}

--- a/charts/cp-ksql-server/values.yaml
+++ b/charts/cp-ksql-server/values.yaml
@@ -94,6 +94,10 @@ kafka:
 cp-schema-registry:
   url: ""
 
+cp-kafka-connect:
+  url: ""
+
+
 # KSQL configuration options
 ## ref: https://docs.confluent.io/current/ksql/docs/installation/server-config/config-reference.html
 configurationOverrides: {}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add the env variable "KSQL_KSQL_CONNECT_URL" to the KSQLDB deployment to be able to create connector viq ksql queries.

## How was this patch tested?

I deployed this PR in minikube for now and will apply it to EKS in some time.
