### PR TITLE
[cp-schema-registry] add support for security context

### DIFF
--- a/charts/cp-schema-registry/README.md
+++ b/charts/cp-schema-registry/README.md
@@ -139,6 +139,16 @@ The configuration parameters in this section control the resources requested and
 | --------- | ----------- | ------- |
 | `podAnnotations` | Map of custom annotations to attach to the pod spec. | `{}` |
 
+### Security Context
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `securityContext.runAsUser` | All processes for the container will run with this user ID | 10001
+| `securityContext.runAsGroup` | All processes for the container will run with this primary group ID | 10001
+| `securityContext.fsGroup` | All processes for the container will run with this supplementary group ID | 10001
+| `securityContext.runAsNonRoot` | The kubelet will validate the image at runtime to make sure that it does not run as UID 0 (root) and won’t start the container if it does | true
+
+
 ### JMX Configuration
 
 | Parameter | Description | Default |

--- a/charts/cp-schema-registry/templates/deployment.yaml
+++ b/charts/cp-schema-registry/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
       {{- end }}
       {{- end }}
     spec:
+      securityContext:
+      {{- if .Values.securityContext }}
+{{ toYaml .Values.securityContext | indent 8 }}
+      {{- end}}
       containers:
         {{- if .Values.prometheus.jmx.enabled }}
         - name: prometheus-jmx-exporter

--- a/charts/cp-schema-registry/values.yaml
+++ b/charts/cp-schema-registry/values.yaml
@@ -69,6 +69,14 @@ tolerations: []
 ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
 affinity: {}
 
+## Privilege and access control settings for a Pod or Container
+## https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+securityContext:
+  runAsUser: 10001
+  runAsGroup: 10001
+  fsGroup: 10001
+  runAsNonRoot: true
+
 ## Monitoring
 ## Schema Registry JMX Settings
 ## ref: https://docs.confluent.io/current/schema-registry/docs/monitoring.html


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allows to configure a security context for the schema registry pods.
For now the containers are running as root.

Having a container, and thus an application, running as root makes it easier for an attacker to exploit the container (installing new packages, editing configuration, etc.). Finally, as container users are mapped on the same user on the host, an attacker breaking out of a container running as root would be root on this host.

## How was this patch tested?

helm install on gke / fluxcd helm operator on gke
