### PR TITLE
Add volumeMounts & volumes to cp-control-center

### DIFF
--- a/charts/cp-control-center/templates/deployment.yaml
+++ b/charts/cp-control-center/templates/deployment.yaml
@@ -66,10 +66,18 @@ spec:
             - name: {{ $key | quote }}
               value: {{ $value | quote }}
             {{- end }}            
+          {{- if .Values.volumeMounts }}
+          volumeMounts:
+{{ toYaml .Values.volumeMounts | indent 10 }}
+          {{- end}}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
       {{- end }}
+      volumes:
+      {{- if .Values.volumes }}
+{{ toYaml .Values.volumes | trim | indent 6 }}
+      {{- end}}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/cp-control-center/values.yaml
+++ b/charts/cp-control-center/values.yaml
@@ -91,6 +91,19 @@ prometheus:
 kafka:
   bootstrapServers: ""
 
+## List of volumeMounts for connect server container
+## ref: https://kubernetes.io/docs/concepts/storage/volumes/
+volumeMounts:
+# - name: credentials
+#   mountPath: /etc/creds-volume
+
+## List of volumeMounts for connect server container
+## ref: https://kubernetes.io/docs/concepts/storage/volumes/
+volumes:
+# - name: credentials
+#   secret:
+#     secretName: creds
+
 ## If the Kafka Chart is disabled a URL and port are required to connect
 ## e.g. gnoble-panther-cp-schema-registry:8081
 cp-schema-registry:


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allow for volumeMounts and Volumes. 

Copied from cp-control-center [volumeMounts](https://github.com/confluentinc/cp-helm-charts/blob/master/charts/cp-kafka-connect/templates/deployment.yaml#L118-L121), [volumes](https://github.com/confluentinc/cp-helm-charts/blob/master/charts/cp-kafka-connect/templates/deployment.yaml#L126-L129) & [value.yaml](https://github.com/confluentinc/cp-helm-charts/blob/master/charts/cp-kafka-connect/values.yaml#L104-L116) 
## How was this patch tested?

It was tested successfully in our own deployment with these additional entries in values.yaml
```yaml
 volumes:
    - name: controlcenter-security-configmap
      configMap:
        name: controlcenter-security-configmap
    - name: confluent-control-center-ui-users
      secret:
        secretName: confluent-control-center-ui-users

  volumeMounts:
    - name: controlcenter-security-configmap
      mountPath: /controlcenter-security
    - name: confluent-control-center-ui-users
      mountPath: /controlcenter-password 
```
