### PR TITLE
use cp-kafka.fullname in the headless service name

### DIFF
--- a/charts/cp-kafka/templates/_helpers.tpl
+++ b/charts/cp-kafka/templates/_helpers.tpl
@@ -72,8 +72,7 @@ Create a default fully qualified kafka headless name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "cp-kafka.cp-kafka-headless.fullname" -}}
-{{- $name := "cp-kafka-headless" -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- printf "%s-headless" (include "cp-kafka.fullname" .) | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
## What changes were proposed in this pull request?

In order to have control over the non-headless kafka service name, I'm changing the "cp-kafka.fullnameOverride", however the kafka pods fail to get into running state because the "cp-kafka-headless.fullname" doesn't follow the "cp-kafka.fullnameOverride" value.

The proposed changes uses the "cp-kafka.fullname" as part of the "cp-kafka-headless.fullname".

Note that the behavior is still the same as before when the "fullnameOverride" is not set because "cp-kafka.fullname" comes out of "printf "%s-%s" .Release.Name $name".

## How was this patch tested?

The changes were tested using "helm install/uninstall ..." in a real k8s cluster.