### PR TITLE
podLabels added to cp-kafka-rest deployment.yaml

### DIFF
--- a/charts/cp-kafka-rest/templates/deployment.yaml
+++ b/charts/cp-kafka-rest/templates/deployment.yaml
@@ -20,6 +20,11 @@ spec:
   template:
     metadata:
       labels:
+      {{- if or .Values.podLabels .Values.prometheus.jmx.enabled }}
+      {{- range $key, $value := .Values.podLabels }}
+        {{ $key }}: {{ $value | quote }}
+      {{- end }}
+      {{- end }}
         app: {{ template "cp-kafka-rest.name" . }}
         release: {{ .Release.Name }}
       {{- if or .Values.podAnnotations .Values.prometheus.jmx.enabled }}

--- a/charts/cp-kafka-rest/values.yaml
+++ b/charts/cp-kafka-rest/values.yaml
@@ -35,6 +35,9 @@ resources: {}
   #  cpu: 100m
   #  memory: 128Mi
 
+## Custom pod labels
+podLabels: {}
+
 ## Custom pod annotations
 podAnnotations: {}
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

A common use-case, one we bumped into immediately when deciding to try out the rest proxy helm charts, is to allow for labels to be (dynamically) added to pods. To facilitate this only a small code-addition is needed. 

This PR contains the necessary change(s) to templates/deployment.yaml.

## How was this patch tested?

- label `harry: "potter"` added to values.yaml
```
## Custom pod labels
podLabels:
  harry: "potter"
```
- helm install on Kube-Docker-Desktop
- k get -o yaml pod/rp-cp-kafka-rest-1234567890
_Voila:_
```
labels:
    app: cp-kafka-rest
    harry: potter
    pod-template-hash: 6bb58dd6bd
    release: rp
```

- label `lord: "voldemort"` added to values.yaml
```
## Custom pod labels
podLabels:
  harry: "potter"
  lord: "voldemort"
```
- helm install on Kube-Docker-Desktop
- k get -o yaml pod/rp-cp-kafka-rest-0987654321
_Voila once more:_
```
 labels:
    app: cp-kafka-rest
    harry: potter
    lord: voldemort
    pod-template-hash: 669dd7cc89
    release: rp
```
