### PR TITLE
[cp-schema-registry] Add ingress support; update JMX exporter

### DIFF
--- a/charts/cp-schema-registry/templates/deployment.yaml
+++ b/charts/cp-schema-registry/templates/deployment.yaml
@@ -44,8 +44,7 @@ spec:
           imagePullPolicy: "{{ .Values.prometheus.jmx.imagePullPolicy }}"
           command:
           - java
-          - -XX:+UnlockExperimentalVMOptions
-          - -XX:+UseCGroupMemoryLimitForHeap
+          - -XX:+UseContainerSupport
           - -XX:MaxRAMFraction=1
           - -XshowSettings:vm
           - -jar

--- a/charts/cp-schema-registry/templates/ingress.yaml
+++ b/charts/cp-schema-registry/templates/ingress.yaml
@@ -1,0 +1,34 @@
+{{- if .Values.ingress.enabled }}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ template "cp-schema-registry.fullname" . }}
+  labels:
+    app: {{ template "cp-schema-registry.fullname" . }}
+    chart: "{{ .Chart.Name }}-{{ .Chart.Version | replace "+" "_" }}"
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- if .Values.ingress.labels }}
+{{ toYaml .Values.ingress.labels | indent 4 }}
+{{- end }}
+{{- if .Values.ingress.annotations }}
+  annotations:
+{{ toYaml .Values.ingress.annotations | indent 4 }}
+{{- end }}
+spec:
+  rules:
+    - host: {{ .Values.ingress.hostname }}
+      http:
+        paths:
+          - path: /
+            backend:
+              serviceName: {{ template "cp-schema-registry.fullname" . }}
+              servicePort: {{ .Values.servicePort }}
+{{- if .Values.ingress.tls.enabled }}
+  tls:
+    - secretName: {{ .Values.ingress.tls.secretName }}
+      hosts:
+        - {{ .Values.ingress.hostname }}
+{{- end -}}
+{{ end -}}
+

--- a/charts/cp-schema-registry/values.yaml
+++ b/charts/cp-schema-registry/values.yaml
@@ -105,8 +105,7 @@ prometheus:
   jmx:
     enabled: true
     image: solsson/kafka-prometheus-jmx-exporter@sha256
-    imageTag: 6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143
+    imageTag: 70852d19ab9182c191684a8b08ac831230006d82e65d1db617479ea27884e4e8
     imagePullPolicy: IfNotPresent
     port: 5556
-
     resources: {}

--- a/charts/cp-schema-registry/values.yaml
+++ b/charts/cp-schema-registry/values.yaml
@@ -42,6 +42,20 @@ heapOptions: "-Xms512M -Xmx512M"
 kafka:
   bootstrapServers: ""
 
+## Provides schema registry ingress settings
+ingress:
+  ## If true provide ingress to the schema registry
+  enabled: false
+  ## Annotations for the ingress, if any
+  annotations: {}
+  ## Hostname of the ingress
+  hostname: ""
+  ## Any additional labels to add to the ingress
+  labels: {}
+  tls:
+    enabled: false
+    secretName: schema-registry-tls
+
 resources: {}
   # We usually recommend not to specify default resources and to leave this as a conscious
   # choice for the user. This also increases chances charts run on environments with little


### PR DESCRIPTION
## What changes were proposed in this pull request?

1. Adds support for created an ingress for `schema-registry`
2. Updates the JMX exporter to the latest version: https://hub.docker.com/layers/solsson/kafka-prometheus-jmx-exporter/latest/images/sha256-70852d19ab9182c191684a8b08ac831230006d82e65d1db617479ea27884e4e8?context=explore

## How was this patch tested?

`helm template schema-registry .` from the root of the `cp-schema-registry` chart
