### PR TITLE
Fix #542

### DIFF
--- a/charts/cp-kafka/templates/_helpers.tpl
+++ b/charts/cp-kafka/templates/_helpers.tpl
@@ -72,8 +72,16 @@ Create a default fully qualified kafka headless name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "cp-kafka.cp-kafka-headless.fullname" -}}
-{{- $name := "cp-kafka-headless" -}}
-{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- if .Values.fullnameOverride -}}
+{{- printf "%s-headless" .Values.fullnameOverride | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- $name := default .Chart.Name .Values.nameOverride -}}
+{{- if contains $name .Release.Name -}}
+{{- printf "%s-headless" .Release.Name | trunc 63 | trimSuffix "-" -}}
+{{- else -}}
+{{- printf "%s-headless" $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+{{- end -}}
 {{- end -}}
 
 {{/*


### PR DESCRIPTION
## What changes were proposed in this pull request?

Modify the `cp-kafka.cp-kafka-headless.fullname` template


## How was this patch tested?

Using 
```shell-script
helm install kafka . -f .\values-modified.yaml --namespace my-ns --set cp-kafka.nodeport.enabled=true
```

Where values-modified.yaml contains
```yaml
cp-zookeeper:
  enabled: true
  fullnameOverride: cp-zookeeper
  servers: 3
  image: confluentinc/cp-zookeeper
  imageTag: 6.2.0

## ------------------------------------------------------
## Kafka
## ------------------------------------------------------
cp-kafka:
  enabled: true
  brokers: 3
  image: confluentinc/cp-enterprise-kafka
  imageTag: 6.2.0
  fullnameOverride: cp-kafka
  cp-zookeeper:
    enabled: false
    url: cp-zookeeper-headless:2181
```