### PR TITLE
Kafka Connect: Allow setting securityContext on deployment

### DIFF
--- a/charts/cp-kafka-connect/README.md
+++ b/charts/cp-kafka-connect/README.md
@@ -144,6 +144,12 @@ The configuration parameters in this section control the resources requested and
 | --------- | ----------- | ------- |
 | `podAnnotations` | Map of custom annotations to attach to the pod spec. | `{}` |
 
+### Security Context
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `securityContext` | Security context settings to set to the pod spec. | see [values.yaml](values.yaml) for details |
+
 ### JMX Configuration
 
 | Parameter | Description | Default |

--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -144,3 +144,6 @@ spec:
       affinity:
 {{ toYaml .Values.affinity | indent 8 }}
       {{- end }}
+      securityContext:
+{{ toYaml .Values.securityContext | indent 8 }}
+

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -133,3 +133,10 @@ livenessProbe:
   # initialDelaySeconds: 30
   # periodSeconds: 5
   # failureThreshold: 10
+
+## Security context for the pod
+## ref: https://kubernetes.io/docs/tasks/configure-pod-container/security-context/#set-the-security-context-for-a-pod
+securityContext:
+  # runAsUser: 1000
+  # runAsGroup: 1000
+  # fsGroup: 1000


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR helps to allow the user to specify securityContext settings to the cp-kafka-connect helm chart through values.yaml

## How was this patch tested?

Placed chart files inside chart/ folder
Command:
helm upgrade --install my-kafka-connect chart/ -f values.yaml