### PR TITLE
adjuste _helpers.tpl fullnameOverride and Release.Namespace headless …

### DIFF
--- a/charts/cp-kafka/templates/_helpers.tpl
+++ b/charts/cp-kafka/templates/_helpers.tpl
@@ -72,8 +72,12 @@ Create a default fully qualified kafka headless name.
 We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
 */}}
 {{- define "cp-kafka.cp-kafka-headless.fullname" -}}
+{{- if .Values.fullnameOverride -}}
+{{- printf "%s-headless.%s" .Values.fullnameOverride .Release.Namespace | trunc 63 | trimSuffix "-" -}}   
+{{- else -}}
 {{- $name := "cp-kafka-headless" -}}
 {{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
 {{- end -}}
 
 {{/*

--- a/charts/cp-kafka/values.yaml
+++ b/charts/cp-kafka/values.yaml
@@ -8,7 +8,6 @@
 
 ## Number of Kafka brokers
 brokers: 3
-
 ## Image Info
 ## ref: https://hub.docker.com/r/confluentinc/cp-server/
 image: confluentinc/cp-server


### PR DESCRIPTION
…svc CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS

## What changes were proposed in this pull request?
When you use FullnameOverride in helm chart env  CONFLUENT_METRICS_REPORTER_BOOTSTRAP_SERVERS never override value and broken deploy.

Log:
```sh
[2021-08-30 19:59:55,361] WARN Couldn't resolve server PLAINTEXT://kafkateste-cp-kafka-headless:9092 from bootstrap.servers as DNS resolution failed for kafkateste-cp-kafka-headless (org.apache.kafka.clients.ClientUtils)
[2021-08-30 19:59:55,361] INFO [Producer clientId=confluent-metrics-reporter] Closing the Kafka producer with timeoutMillis = 0 ms. (org.apache.kafka.clients.producer.KafkaProducer)
[2021-08-30 19:59:55,363] INFO Metrics scheduler closed (org.apache.kafka.common.metrics.Metrics)
[2021-08-30 19:59:55,363] INFO Closing reporter org.apache.kafka.common.metricssd.JmxReporter (org.apache.kafka.common.metrics.Metrics)
[2021-08-30 19:59:55,363] INFO Metrics reporters closed (org.apache.kafka.common.metrics.Metrics)
(Please fill in changes proposed in this fix)
```
## How was this patch tested?

(Please explain how this patch was tested. E.g. helm upgrade on minikube, helm install on gke)

```yaml
cp-kafka:
  enabled: true
  brokers: 3
  image: confluentinc/cp-server 
  imageTag: 6.1.0
  configurationOverrides:
    "offsets.topic.replication.factor": "3"
    "bootstrap.servers": "PLAINTEXT://testkfk-headless.testkfk.svc:9092"
    "listener.security.protocol.map": |-
     PLAINTEXT:PLAINTEXT,EXTERNAL:PLAINTEXT
  jmx:
    port: 5555
  prometheus:
    jmx:
      enabled: false
      image: solsson/kafka-prometheus-jmx-exporter@sha256
      imageTag: 6f82e2b0464f50da8104acd7363fb9b995001ddff77d248379f8788e78946143
      imagePullPolicy: IfNotPresent
      port: 5556    
  heapOptions: "-Xms512M -Xmx512M"
  persistence:
    enabled: true
    # storageClass: ""
    size: 5Gi
    disksPerBroker: 1
  resources: 
    limits:
     cpu: 500m
     memory: 1024Mi
    requests:
     cpu: 250m
     memory: 512Mi
  securityContext: 
    runAsUser: 0 
  cp-zookeeper:
    enabled: false
    fullname: 
    url: "zkeeper.testkfk.svc:2181"
## ------------------------------------------------------
## Zookeeper
## ------------------------------------------------------
cp-zookeeper:
  fullnameOverride: zkeeper
  enabled: true
  servers: 3
  image: confluentinc/cp-zookeeper
  imageTag: 6.1.0
  ## Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
  ## https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod
  imagePullSecrets:
  #  - name: "regcred"
  heapOptions: "-Xms512M -Xmx512M"
  securityContext: 
    runAsUser: 0
  persistence:
    enabled: true
    ## The size of the PersistentVolume to allocate to each Zookeeper Pod in the StatefulSet. For
    ## production servers this number should likely be much larger.
    ##
    ## Size for Data dir, where ZooKeeper will store the in-memory database snapshots.
    dataDirSize: 10Gi
    # dataDirStorageClass: ""
    ## Size for data log dir, which is a dedicated log device to be used, and helps avoid competition between logging and snaphots.
    dataLogDirSize: 10Gi
    # dataLogDirStorageClass: ""    
```

```sh
kubectl create ns testkfk
helm install kafka confluentinc/cp-helm-charts -n testkfk -f  ./values.yaml \
   --set=cp-schema-registry.enabled=false  \ 
   --set=cp-kafka-rest.enabled=false \ 
   --set=cp-ksql-server.enabled=false \ 
   --set=cp-control-center.enabled=false \
   --set=cp-kafka-connect.enabled=false \
   --set=cp-kafka.fullnameOverride=testkfk
```