### PR TITLE
[cp-kafka-connect] Add sink and error metrics to JMX configmap

### DIFF
--- a/charts/cp-kafka-connect/templates/jmx-configmap.yaml
+++ b/charts/cp-kafka-connect/templates/jmx-configmap.yaml
@@ -18,7 +18,16 @@ data:
     - kafka.connect:type=connect-worker-metrics
     - kafka.connect:type=connect-metrics,client-id=*
     - kafka.connect:type=connector-task-metrics,connector=*,task=*
+    - kafka.connect:type=task-error-metrics,connector=*,task=*
+    - kafka.connect:type=sink-task-metrics,connector=*,task=*
     rules:
+    - pattern: kafka.connect<type=(.+)-metrics, connector=(.+), task=(.+)><>(.+-total|.+-count|.+-ms|.+-ratio|.+-avg|.+-failures|.+-requests|.+-timestamp|.+-logged|.+-errors|.+-retries|.+-skipped)
+      name: kafka_connect_$1_$4
+      labels:
+        connector: "$2"
+        task: "$3"
+      help: "Kafka Connect JMX metric type $1"
+      type: GAUGE
     - pattern : "kafka.connect<type=connect-worker-metrics>([^:]+):"
       name: "cp_kafka_connect_connect_worker_metrics_$1"
     - pattern : "kafka.connect<type=connect-metrics, client-id=([^:]+)><>([^:]+)"


### PR DESCRIPTION
The default metrics are not enough. I'd like to add these metrics to monitor the success/ failure rate of messages being sent by the sink.

## What changes were proposed in this pull request?

* The addition of two entries in the whitelist section (two metrics)
* Rule to track Sink and Error metrics
## How was this patch tested?
1. Manually edited the config map after deployment
```
k edit configmap kafka-connect-jmx-configmap
```
2. Performed a rollout restart:
```
k rollout restart deployment kafka-connect
```
3. Created a test pod and installed curl
```
k run -i --tty --rm --image ubuntu test-shell bash
apt-get update; apt-get install curl -y
```
4. Logged in to the pod and Curl'd `IP:5556/metrics` to make sure the metrics are advertised.
```
root@test-shell:/# curl -s kafka-connect:5556/metrics | grep kafka_connect_sink_ | egrep -v "HELP|TYPE"
kafka_connect_sink_task_sink_record_read_total{connector="rawpayload",task="0",} 2036.0
kafka_connect_sink_task_put_batch_max_time_ms{connector="rawpayload",task="0",} 0.0
kafka_connect_sink_task_partition_count{connector="rawpayload",task="0",} 1.0
kafka_connect_sink_task_offset_commit_skip_total{connector="rawpayload",task="0",} 0.0
kafka_connect_sink_task_put_batch_avg_time_ms{connector="rawpayload",task="0",} 0.0
kafka_connect_sink_task_offset_commit_completion_total{connector="rawpayload",task="0",} 87.0
kafka_connect_sink_task_sink_record_active_count{connector="rawpayload",task="0",} 0.0
kafka_connect_sink_task_sink_record_active_count{connector="rawpayload",task="0",} 0.0
kafka_connect_sink_task_sink_record_active_count{connector="rawpayload",task="0",} 0.0
kafka_connect_sink_task_sink_record_send_total{connector="rawpayload",task="0",} 2036.0
```