### PR TITLE
Add possibility to set servicetype of schema-registry and kafka services

### DIFF
--- a/charts/cp-kafka/templates/service.yaml
+++ b/charts/cp-kafka/templates/service.yaml
@@ -8,6 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  type: {{ .Values.serviceType }}
   ports:
     - port: 9092
       name: broker

--- a/charts/cp-schema-registry/templates/service.yaml
+++ b/charts/cp-schema-registry/templates/service.yaml
@@ -8,6 +8,7 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  type: {{ .Values.serviceType }}
   ports:
     - name: schema-registry
       port: {{ .Values.servicePort }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add possibility to set servicetype of zookeeper and kafka services in the same way it is done for cp-zookeeper. This allows the users to set the service as a LoadBalancer/ClusterIP/NodePort

