### PR TITLE
Support custom rules for jmx prometheus exporter

### DIFF
--- a/charts/cp-kafka-connect/templates/jmx-configmap.yaml
+++ b/charts/cp-kafka-connect/templates/jmx-configmap.yaml
@@ -14,20 +14,10 @@ data:
     lowercaseOutputName: true
     lowercaseOutputLabelNames: true
     ssl: false
+    {{- if .Values.prometheus.jmx.whitelistObjectNames }}
     whitelistObjectNames:
-    - kafka.connect:type=connect-worker-metrics
-    - kafka.connect:type=connect-metrics,client-id=*
-    - kafka.connect:type=connector-task-metrics,connector=*,task=*
+{{ toYaml .Values.prometheus.jmx.whitelistObjectNames | trim | indent 4 }}
+    {{- end }}
     rules:
-    - pattern : "kafka.connect<type=connect-worker-metrics>([^:]+):"
-      name: "cp_kafka_connect_connect_worker_metrics_$1"
-    - pattern : "kafka.connect<type=connect-metrics, client-id=([^:]+)><>([^:]+)"
-      name: "cp_kafka_connect_connect_metrics_$1_$2"
-    - pattern : "kafka.connect<type=connector-task-metrics, connector=([^:]+), task=([^:]+)><>status: ([^:]+)"
-      name: "cp_kafka_connect_connect_connector_metrics"
-      value: 1
-      labels:
-        connector: $1
-        task: $2
-        status: $3
+{{ tpl .Values.prometheus.jmx.rules . | indent 4 }}
 {{- end }}

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -91,6 +91,23 @@ prometheus:
     ## See the `resources` documentation above for details.
     resources: {}
 
+    whitelistObjectNames:
+      - kafka.connect:type=connect-worker-metrics
+      - kafka.connect:type=connect-metrics,client-id=*
+      - kafka.connect:type=connector-task-metrics,connector=*,task=*
+    rules: |
+      - pattern: "kafka.connect<type=connect-worker-metrics>([^:]+):"
+        name: "cp_kafka_connect_connect_worker_metrics_$1"
+      - pattern: "kafka.connect<type=connect-metrics, client-id=([^:]+)><>([^:]+)"
+        name: "cp_kafka_connect_connect_metrics_$1_$2"
+      - pattern: "kafka.connect<type=connector-task-metrics, connector=([^:]+), task=([^:]+)><>status: ([^:]+)"
+        name: "cp_kafka_connect_connect_connector_metrics"
+        value: 1
+        labels:
+          connector: $1
+          task: $2
+          status: $3
+
 ## You can list load balanced service endpoint, or list of all brokers (which is hard in K8s).  e.g.:
 ## bootstrapServers: "PLAINTEXT://dozing-prawn-kafka-headless:9092"
 kafka:

--- a/charts/cp-kafka-rest/templates/jmx-configmap.yaml
+++ b/charts/cp-kafka-rest/templates/jmx-configmap.yaml
@@ -14,12 +14,10 @@ data:
     lowercaseOutputName: true
     lowercaseOutputLabelNames: true
     ssl: false
+    {{- if .Values.prometheus.jmx.whitelistObjectNames }}
     whitelistObjectNames:
-    - kafka.rest:type=jetty-metrics
-    - kafka.rest:type=jersey-metrics
+{{ toYaml .Values.prometheus.jmx.whitelistObjectNames | trim | indent 4 }}
+    {{- end }}
     rules:
-    - pattern : 'kafka.rest<type=jetty-metrics>([^:]+):'
-      name: "cp_kafka_rest_jetty_metrics_$1"
-    - pattern : 'kafka.rest<type=jersey-metrics>([^:]+):'
-      name: "cp_kafka_rest_jersey_metrics_$1"
+{{ tpl .Values.prometheus.jmx.rules . | indent 4 }}
 {{- end }}

--- a/charts/cp-kafka-rest/values.yaml
+++ b/charts/cp-kafka-rest/values.yaml
@@ -81,6 +81,15 @@ prometheus:
     ## See the `resources` documentation above for details.
     resources: {}
 
+    whitelistObjectNames:
+      - kafka.rest:type=jetty-metrics
+      - kafka.rest:type=jersey-metrics
+    rules: |
+      - pattern : 'kafka.rest<type=jetty-metrics>([^:]+):'
+        name: "cp_kafka_rest_jetty_metrics_$1"
+      - pattern : 'kafka.rest<type=jersey-metrics>([^:]+):'
+        name: "cp_kafka_rest_jersey_metrics_$1"
+
 ## External Access
 ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
 external:

--- a/charts/cp-kafka/templates/jmx-configmap.yaml
+++ b/charts/cp-kafka/templates/jmx-configmap.yaml
@@ -14,33 +14,10 @@ data:
     lowercaseOutputName: true
     lowercaseOutputLabelNames: true
     ssl: false
+    {{- if .Values.prometheus.jmx.whitelistObjectNames }}
     whitelistObjectNames:
-    - kafka.server:type=ReplicaManager,name=*
-    - kafka.controller:type=KafkaController,name=*
-    - kafka.server:type=BrokerTopicMetrics,name=*
-    - kafka.network:type=RequestMetrics,name=RequestsPerSec,request=*
-    - kafka.network:type=SocketServer,name=NetworkProcessorAvgIdlePercent
-    - kafka.server:type=ReplicaFetcherManager,name=MaxLag,clientId=*
-    - kafka.server:type=KafkaRequestHandlerPool,name=RequestHandlerAvgIdlePercent
-    - kafka.controller:type=ControllerStats,name=*
-    - kafka.server:type=SessionExpireListener,name=*
+{{ toYaml .Values.prometheus.jmx.whitelistObjectNames | trim | indent 4 }}
+    {{- end }}
     rules:
-    - pattern : kafka.server<type=ReplicaManager, name=(.+)><>(Value|OneMinuteRate)
-      name: "cp_kafka_server_replicamanager_$1"
-    - pattern : kafka.controller<type=KafkaController, name=(.+)><>Value
-      name: "cp_kafka_controller_kafkacontroller_$1"
-    - pattern : kafka.server<type=BrokerTopicMetrics, name=(.+)><>OneMinuteRate
-      name: "cp_kafka_server_brokertopicmetrics_$1"
-    - pattern : kafka.network<type=RequestMetrics, name=RequestsPerSec, request=(.+)><>OneMinuteRate
-      name: "cp_kafka_network_requestmetrics_requestspersec_$1"
-    - pattern : kafka.network<type=SocketServer, name=NetworkProcessorAvgIdlePercent><>Value
-      name: "cp_kafka_network_socketserver_networkprocessoravgidlepercent"
-    - pattern : kafka.server<type=ReplicaFetcherManager, name=MaxLag, clientId=(.+)><>Value
-      name: "cp_kafka_server_replicafetchermanager_maxlag_$1"
-    - pattern : kafka.server<type=KafkaRequestHandlerPool, name=RequestHandlerAvgIdlePercent><>OneMinuteRate
-      name: "cp_kafka_kafkarequesthandlerpool_requesthandleravgidlepercent"
-    - pattern : kafka.controller<type=ControllerStats, name=(.+)><>OneMinuteRate
-      name: "cp_kafka_controller_controllerstats_$1"
-    - pattern : kafka.server<type=SessionExpireListener, name=(.+)><>OneMinuteRate
-      name: "cp_kafka_server_sessionexpirelistener_$1"
+{{ tpl .Values.prometheus.jmx.rules . | indent 4 }}
 {{- end }}

--- a/charts/cp-kafka/values.yaml
+++ b/charts/cp-kafka/values.yaml
@@ -134,6 +134,36 @@ prometheus:
     ## See the `resources` documentation above for details.
     resources: {}
 
+    whitelistObjectNames:
+      - kafka.server:type=ReplicaManager,name=*
+      - kafka.controller:type=KafkaController,name=*
+      - kafka.server:type=BrokerTopicMetrics,name=*
+      - kafka.network:type=RequestMetrics,name=RequestsPerSec,request=*
+      - kafka.network:type=SocketServer,name=NetworkProcessorAvgIdlePercent
+      - kafka.server:type=ReplicaFetcherManager,name=MaxLag,clientId=*
+      - kafka.server:type=KafkaRequestHandlerPool,name=RequestHandlerAvgIdlePercent
+      - kafka.controller:type=ControllerStats,name=*
+      - kafka.server:type=SessionExpireListener,name=*
+    rules: |
+      - pattern : kafka.server<type=ReplicaManager, name=(.+)><>(Value|OneMinuteRate)
+        name: "cp_kafka_server_replicamanager_$1"
+      - pattern : kafka.controller<type=KafkaController, name=(.+)><>Value
+        name: "cp_kafka_controller_kafkacontroller_$1"
+      - pattern : kafka.server<type=BrokerTopicMetrics, name=(.+)><>OneMinuteRate
+        name: "cp_kafka_server_brokertopicmetrics_$1"
+      - pattern : kafka.network<type=RequestMetrics, name=RequestsPerSec, request=(.+)><>OneMinuteRate
+        name: "cp_kafka_network_requestmetrics_requestspersec_$1"
+      - pattern : kafka.network<type=SocketServer, name=NetworkProcessorAvgIdlePercent><>Value
+        name: "cp_kafka_network_socketserver_networkprocessoravgidlepercent"
+      - pattern : kafka.server<type=ReplicaFetcherManager, name=MaxLag, clientId=(.+)><>Value
+        name: "cp_kafka_server_replicafetchermanager_maxlag_$1"
+      - pattern : kafka.server<type=KafkaRequestHandlerPool, name=RequestHandlerAvgIdlePercent><>OneMinuteRate
+        name: "cp_kafka_kafkarequesthandlerpool_requesthandleravgidlepercent"
+      - pattern : kafka.controller<type=ControllerStats, name=(.+)><>OneMinuteRate
+        name: "cp_kafka_controller_controllerstats_$1"
+      - pattern : kafka.server<type=SessionExpireListener, name=(.+)><>OneMinuteRate
+        name: "cp_kafka_server_sessionexpirelistener_$1"
+
 nodeport:
   enabled: false
   servicePort: 19092

--- a/charts/cp-ksql-server/templates/jmx-configmap.yaml
+++ b/charts/cp-ksql-server/templates/jmx-configmap.yaml
@@ -14,9 +14,10 @@ data:
     lowercaseOutputName: true
     lowercaseOutputLabelNames: true
     ssl: false
+    {{- if .Values.prometheus.jmx.whitelistObjectNames }}
     whitelistObjectNames:
-    - io.confluent.ksql.metrics:type=ksql-engine-query-stats
+{{ toYaml .Values.prometheus.jmx.whitelistObjectNames | trim | indent 4 }}
+    {{- end }}
     rules:
-    - pattern : 'io.confluent.ksql.metrics<type=ksql-engine-query-stats>([^:]+):'
-      name: "cp_ksql_server_metrics_$1"
+{{ tpl .Values.prometheus.jmx.rules . | indent 4 }}
 {{- end }}

--- a/charts/cp-ksql-server/values.yaml
+++ b/charts/cp-ksql-server/values.yaml
@@ -72,6 +72,12 @@ prometheus:
     ## See the `resources` documentation above for details.
     resources: {}
 
+    whitelistObjectNames:
+      - io.confluent.ksql.metrics:type=ksql-engine-query-stats
+    rules: |
+      - pattern: 'io.confluent.ksql.metrics<type=ksql-engine-query-stats>([^:]+):'
+        name: "cp_ksql_server_metrics_$1"
+
 ## External Access
 ## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
 external:

--- a/charts/cp-schema-registry/templates/jmx-configmap.yaml
+++ b/charts/cp-schema-registry/templates/jmx-configmap.yaml
@@ -14,15 +14,10 @@ data:
     lowercaseOutputName: true
     lowercaseOutputLabelNames: true
     ssl: false
+    {{- if .Values.prometheus.jmx.whitelistObjectNames }}
     whitelistObjectNames:
-    - kafka.schema.registry:type=jetty-metrics
-    - kafka.schema.registry:type=master-slave-role
-    - kafka.schema.registry:type=jersey-metrics
+{{ toYaml .Values.prometheus.jmx.whitelistObjectNames | trim | indent 4 }}
+    {{- end }}
     rules:
-    - pattern : 'kafka.schema.registry<type=jetty-metrics>([^:]+):'
-      name: "cp_kafka_schema_registry_jetty_metrics_$1"
-    - pattern : 'kafka.schema.registry<type=master-slave-role>([^:]+):'
-      name: "cp_kafka_schema_registry_master_slave_role"
-    - pattern : 'kafka.schema.registry<type=jersey-metrics>([^:]+):'
-      name: "cp_kafka_schema_registry_jersey_metrics_$1"
+{{ tpl .Values.prometheus.jmx.rules . | indent 4 }}
 {{- end }}

--- a/charts/cp-schema-registry/values.yaml
+++ b/charts/cp-schema-registry/values.yaml
@@ -96,3 +96,15 @@ prometheus:
     port: 5556
 
     resources: {}
+
+    whitelistObjectNames:
+      - kafka.schema.registry:type=jetty-metrics
+      - kafka.schema.registry:type=master-slave-role
+      - kafka.schema.registry:type=jersey-metrics
+    rules: |
+      - pattern: 'kafka.schema.registry<type=jetty-metrics>([^:]+):'
+        name: "cp_kafka_schema_registry_jetty_metrics_$1"
+      - pattern: 'kafka.schema.registry<type=master-slave-role>([^:]+):'
+        name: "cp_kafka_schema_registry_master_slave_role"
+      - pattern: 'kafka.schema.registry<type=jersey-metrics>([^:]+):'
+        name: "cp_kafka_schema_registry_jersey_metrics_$1"

--- a/charts/cp-zookeeper/templates/jmx-configmap.yaml
+++ b/charts/cp-zookeeper/templates/jmx-configmap.yaml
@@ -14,26 +14,10 @@ data:
     lowercaseOutputName: true
     lowercaseOutputLabelNames: true
     ssl: false
+    {{- if .Values.prometheus.jmx.whitelistObjectNames }}
     whitelistObjectNames:
-    - org.apache.ZooKeeperService:name0=ReplicatedServer_id*
-    - org.apache.ZooKeeperService:name0=ReplicatedServer_id*,name1=replica.*
-    - org.apache.ZooKeeperService:name0=ReplicatedServer_id*,name1=replica.*,name2=*
-    - org.apache.ZooKeeperService:name0=ReplicatedServer_id*,name1=replica.*,name2=*,name3=*
+{{ toYaml .Values.prometheus.jmx.whitelistObjectNames | trim | indent 4 }}
+    {{- end }}
     rules:
-    - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+)><>(\\w+)"
-      name: "cp_zookeeper_$2"
-    - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+), name1=replica.(\\d+)><>(\\w+)"
-      name: "cp_zookeeper_$3"
-      labels:
-        replicaId: "$2"
-    - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+), name1=replica.(\\d+), name2=(\\w+)><>(\\w+)"
-      name: "cp_zookeeper_$4"
-      labels:
-        replicaId: "$2"
-        memberType: "$3"
-    - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+), name1=replica.(\\d+), name2=(\\w+), name3=(\\w+)><>(\\w+)"
-      name: "cp_zookeeper_$4_$5"
-      labels:
-        replicaId: "$2"
-        memberType: "$3"
+{{ tpl .Values.prometheus.jmx.rules . | indent 4 }}
 {{- end }}

--- a/charts/cp-zookeeper/values.yaml
+++ b/charts/cp-zookeeper/values.yaml
@@ -128,3 +128,26 @@ prometheus:
     ## Resources configuration for the JMX exporter container.
     ## See the `resources` documentation above for details.
     resources: {}
+
+    whitelistObjectNames:
+      - org.apache.ZooKeeperService:name0=ReplicatedServer_id*
+      - org.apache.ZooKeeperService:name0=ReplicatedServer_id*,name1=replica.*
+      - org.apache.ZooKeeperService:name0=ReplicatedServer_id*,name1=replica.*,name2=*
+      - org.apache.ZooKeeperService:name0=ReplicatedServer_id*,name1=replica.*,name2=*,name3=*
+    rules: |
+      - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+)><>(\\w+)"
+        name: "cp_zookeeper_$2"
+      - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+), name1=replica.(\\d+)><>(\\w+)"
+        name: "cp_zookeeper_$3"
+        labels:
+          replicaId: "$2"
+      - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+), name1=replica.(\\d+), name2=(\\w+)><>(\\w+)"
+        name: "cp_zookeeper_$4"
+        labels:
+          replicaId: "$2"
+          memberType: "$3"
+      - pattern: "org.apache.ZooKeeperService<name0=ReplicatedServer_id(\\d+), name1=replica.(\\d+), name2=(\\w+), name3=(\\w+)><>(\\w+)"
+        name: "cp_zookeeper_$4_$5"
+        labels:
+          replicaId: "$2"
+          memberType: "$3"


### PR DESCRIPTION
## What changes were proposed in this pull request?

partially resolve https://github.com/confluentinc/cp-helm-charts/issues/504 issue.

### Context
I'd like to configure rules in jmx prometheus exporter.
But there is no way to customize it.
So I added `.Values.prometheus.jmx.rules`, `.Values.prometheus.jmx.whitelistObjectNames` and move default rules to there.

## How was this patch tested?

helm install on eks