### PR TITLE
Add Service Account Support

### DIFF
--- a/charts/cp-control-center/templates/deployment.yaml
+++ b/charts/cp-control-center/templates/deployment.yaml
@@ -33,6 +33,9 @@ spec:
       {{- end }}
       {{- end }}
     spec:
+      {{- if .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.image }}:{{ .Values.imageTag }}"
@@ -65,7 +68,7 @@ spec:
             {{- range $key, $value := .Values.customEnv }}
             - name: {{ $key | quote }}
               value: {{ $value | quote }}
-            {{- end }}            
+            {{- end }}
       {{- if .Values.imagePullSecrets }}
       imagePullSecrets:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}

--- a/charts/cp-control-center/templates/serviceaccount.yaml
+++ b/charts/cp-control-center/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ include "cp-control-center.name" . }}
+    chart: {{ include "cp-control-center.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+  name: {{ .Values.serviceAccount.name }}
+{{- end }}

--- a/charts/cp-control-center/values.yaml
+++ b/charts/cp-control-center/values.yaml
@@ -2,6 +2,11 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+serviceAccount:
+  create: true
+  name:
+  annotations: {}  
+
 replicaCount: 1
 
 ## Image Info

--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -33,6 +33,9 @@ spec:
       {{- end }}
       {{- end }}
     spec:
+      {{- if .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- end }}
       containers:
         {{- if .Values.prometheus.jmx.enabled }}
         - name: prometheus-jmx-exporter

--- a/charts/cp-kafka-connect/templates/serviceaccount.yaml
+++ b/charts/cp-kafka-connect/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ include "cp-kafka-connect.name" . }}
+    chart: {{ include "cp-kafka-connect.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+  name: {{ .Values.serviceAccount.name }}
+{{- end }}

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -2,6 +2,11 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+serviceAccount:
+  create: true
+  name:
+  annotations: {}  
+  
 replicaCount: 1
 
 ## Image Info

--- a/charts/cp-kafka-rest/templates/deployment.yaml
+++ b/charts/cp-kafka-rest/templates/deployment.yaml
@@ -33,6 +33,9 @@ spec:
       {{- end }}
       {{- end }}
     spec:
+      {{- if .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- end }}
       containers:
         {{- if .Values.prometheus.jmx.enabled }}
         - name: prometheus-jmx-exporter

--- a/charts/cp-kafka-rest/templates/serviceaccount.yaml
+++ b/charts/cp-kafka-rest/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "cp-kafka-rest.name" . }}
+    chart: {{ template "cp-kafka-rest.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+  name: {{ .Values.serviceAccount.name }}
+{{- end }}

--- a/charts/cp-kafka-rest/values.yaml
+++ b/charts/cp-kafka-rest/values.yaml
@@ -2,6 +2,11 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+serviceAccount:
+  create: true
+  name:
+  annotations: {}  
+
 replicaCount: 1
 
 ## Image Info

--- a/charts/cp-kafka/templates/serviceaccount.yaml
+++ b/charts/cp-kafka/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ include "cp-kafka.name" . }}
+    chart: {{ include "cp-kafka.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+  name: {{ .Values.serviceAccount.name }}
+{{- end }}

--- a/charts/cp-kafka/templates/statefulset.yaml
+++ b/charts/cp-kafka/templates/statefulset.yaml
@@ -39,6 +39,9 @@ spec:
       {{- end }}
       {{- end }}
     spec:
+      {{- if .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- end }}
       affinity:
       {{- if .Values.affinity }}
 {{ toYaml .Values.affinity | indent 8 }}

--- a/charts/cp-kafka/values.yaml
+++ b/charts/cp-kafka/values.yaml
@@ -6,6 +6,11 @@
 ## Kafka
 ## ------------------------------------------------------
 
+serviceAccount:
+  create: true
+  name:
+  annotations: {}  
+
 ## Number of Kafka brokers
 brokers: 3
 

--- a/charts/cp-ksql-server/templates/deployment.yaml
+++ b/charts/cp-ksql-server/templates/deployment.yaml
@@ -33,6 +33,9 @@ spec:
       {{- end }}
       {{- end }}
     spec:
+      {{- if .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- end }}
       containers:
         {{- if .Values.prometheus.jmx.enabled }}
         - name: prometheus-jmx-exporter

--- a/charts/cp-ksql-server/templates/serviceaccount.yaml
+++ b/charts/cp-ksql-server/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "cp-ksql-server.name" . }}
+    chart: {{ template "cp-ksql-server.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+  name: {{ .Values.serviceAccount.name }}
+{{- end }}

--- a/charts/cp-ksql-server/values.yaml
+++ b/charts/cp-ksql-server/values.yaml
@@ -2,6 +2,11 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+serviceAccount:
+  create: true
+  name:
+  annotations: {}  
+
 replicaCount: 1
 
 ## Image Info

--- a/charts/cp-schema-registry/templates/deployment.yaml
+++ b/charts/cp-schema-registry/templates/deployment.yaml
@@ -33,6 +33,9 @@ spec:
       {{- end }}
       {{- end }}
     spec:
+      {{- if .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- end }}
       securityContext:
       {{- if .Values.securityContext }}
 {{ toYaml .Values.securityContext | indent 8 }}

--- a/charts/cp-schema-registry/templates/serviceaccount.yaml
+++ b/charts/cp-schema-registry/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "cp-schema-registry.name" . }}
+    chart: {{ template "cp-schema-registry.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+  name: {{ .Values.serviceAccount.name }}
+{{- end }}

--- a/charts/cp-schema-registry/values.yaml
+++ b/charts/cp-schema-registry/values.yaml
@@ -6,6 +6,11 @@
 ## Schema Registry
 ## ------------------------------------------------------
 
+serviceAccount:
+  create: true
+  name:
+  annotations: {}  
+
 ## Number of Scheme Registry Pod
 replicaCount: 1
 

--- a/charts/cp-zookeeper/templates/serviceaccount.yaml
+++ b/charts/cp-zookeeper/templates/serviceaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  labels:
+    app: {{ template "cp-zookeeper.name" . }}
+    chart: {{ template "cp-zookeeper.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- with .Values.serviceAccount.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+  name: {{ .Values.serviceAccount.name }}
+{{- end }}

--- a/charts/cp-zookeeper/templates/statefulset.yaml
+++ b/charts/cp-zookeeper/templates/statefulset.yaml
@@ -39,6 +39,9 @@ spec:
       {{- end }}
       {{- end }}
     spec:
+      {{- if .Values.serviceAccount.name }}
+      serviceAccountName: {{ .Values.serviceAccount.name }}
+      {{- end }}
       affinity:
       {{- if .Values.affinity }}
 {{ toYaml .Values.affinity | indent 8 }}

--- a/charts/cp-zookeeper/values.yaml
+++ b/charts/cp-zookeeper/values.yaml
@@ -6,6 +6,11 @@
 ## Zookeeper
 ## ------------------------------------------------------
 
+serviceAccount:
+  create: true
+  name:
+  annotations: {}  
+
 ## Number of zookeeper servers, should be odd number
 servers: 3
 


### PR DESCRIPTION
## What changes were proposed in this pull request?

I use eks and kafka connect s3 sink to where my pods needs to assume an iam role
https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html

## How was this patch tested?

I am currently using this in prod.

Example
```
  cp-kafka-xxx:
    enabled: true
    serviceAccount:
      create: true
      name: cp-kafka-xxxx
      annotations:
        eks.amazonaws.com/role-arn: arn:aws:iam::xxx:role/xxxx
```

