### PR TITLE
#578 - Adds external-service.yaml to cp-kafka-connect-chart

### DIFF
--- a/charts/cp-kafka-connect/templates/external-service.yaml
+++ b/charts/cp-kafka-connect/templates/external-service.yaml
@@ -1,0 +1,33 @@
+{{- if .Values.external.enabled -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ template "cp-kafka-connect.fullname" . }}-external
+  {{- if .Values.external.annotations }}
+  annotations:
+  {{- range $key, $value := .Values.external.annotations }}
+    {{ $key }}: "{{ $value }}"
+  {{- end }}
+  {{- end }}
+  labels:
+    app: {{ template "cp-kafka-connect.name" . }}
+    chart: {{ template "cp-kafka-connect.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+spec:
+  type: {{ .Values.external.type }}
+  externalTrafficPolicy: {{ .Values.external.externalTrafficPolicy }}
+  {{- if .Values.external.loadBalancerSourceRanges }}
+  loadBalancerSourceRanges:
+  {{- range $cidr := .Values.external.loadBalancerSourceRanges }}
+    - {{ $cidr }}
+  {{- end }}
+  {{- end }}
+  ports:
+    - name: server-proxy
+      port: {{ .Values.external.port }}
+      targetPort: {{ .Values.servicePort }}
+  selector:
+    app: {{ template "cp-kafka-connect.name" . }}
+    release: {{ .Release.Name }}
+{{- end -}}

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -133,3 +133,11 @@ livenessProbe:
   # initialDelaySeconds: 30
   # periodSeconds: 5
   # failureThreshold: 10
+
+## External Access
+## ref: https://kubernetes.io/docs/concepts/services-networking/service/#type-loadbalancer
+external:
+  enabled: false
+  type: LoadBalancer
+  externalTrafficPolicy: Cluster
+  port: 8083


### PR DESCRIPTION
This shamelessly copies the external-service.yaml from the cp-ksql-server chart template.

## What changes were proposed in this pull request?

Adds an external-service.yaml for the cp-kafka-connect helm chart that allows the kafka-connect service to be accessible externally to the cluster

## How was this patch tested?

Kubernetes for docker desktop was used in conjunction with helmfile to setup the kafka-connect service. A test script that sets up a connector was able to successfully reach the kafka-connect service from outside of the kubernetes cluster on localhost port 8083.
