### PR TITLE
Add support for kafka-connect deployment `spec.strategy`

### DIFF
--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -17,6 +17,10 @@ spec:
     matchLabels:
       app: {{ template "cp-kafka-connect.name" . }}
       release: {{ .Release.Name }}
+  {{- if .Values.strategy }}
+  strategy:
+{{ toYaml .Values.strategy | indent 4 }}
+  {{- end }}
   template:
     metadata:
       labels:

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -133,3 +133,10 @@ livenessProbe:
   # initialDelaySeconds: 30
   # periodSeconds: 5
   # failureThreshold: 10
+
+## Deployment update strategy.
+## ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy
+strategy:
+  # rollingUpdate:
+  #   maxSurge: 1
+  #   maxUnavailable: 1


### PR DESCRIPTION
## What changes were proposed in this pull request?

This PR adds the ability to define a deployment's `strategy` for the `kafka-connect` chart. Ref: https://kubernetes.io/docs/concepts/workloads/controllers/deployment/#strategy

## How was this patch tested?

This was first tested by running `helm update --debug --dry-run ...`  and, after that looked clean, this change was used to deploy to our various kubernetes clusters.