### PR TITLE
[cp-kafka-connect] add security context support.

### DIFF
--- a/charts/cp-kafka-connect/README.md
+++ b/charts/cp-kafka-connect/README.md
@@ -144,6 +144,15 @@ The configuration parameters in this section control the resources requested and
 | --------- | ----------- | ------- |
 | `podAnnotations` | Map of custom annotations to attach to the pod spec. | `{}` |
 
+### Security Context
+
+| Parameter | Description | Default |
+| --------- | ----------- | ------- |
+| `securityContext.runAsUser` | All processes for the container will run with this user ID | 10001
+| `securityContext.runAsGroup` | All processes for the container will run with this primary group ID | 10001
+| `securityContext.fsGroup` | All processes for the container will run with this supplementary group ID | 10001
+| `securityContext.runAsNonRoot` | The kubelet will validate the image at runtime to make sure that it does not run as UID 0 (root) and won’t start the container if it does | true
+
 ### JMX Configuration
 
 | Parameter | Description | Default |

--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
       {{- end }}
       {{- end }}
     spec:
+      securityContext:
+      {{- if .Values.securityContext }}
+{{ toYaml .Values.securityContext | indent 8 }}
+      {{- end}}
       containers:
         {{- if .Values.prometheus.jmx.enabled }}
         - name: prometheus-jmx-exporter

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -69,6 +69,14 @@ tolerations: []
 ## Ref: https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#affinity-and-anti-affinity
 affinity: {}
 
+## Privilege and access control settings for a Pod or Container
+## https://kubernetes.io/docs/tasks/configure-pod-container/security-context/
+securityContext:
+  runAsUser: 10001
+  runAsGroup: 10001
+  fsGroup: 10001
+  runAsNonRoot: true
+
 ## Monitoring
 ## Kafka Connect JMX Settings
 ## ref: https://kafka.apache.org/documentation/#connect_monitoring


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allows configuring a security context for Kafka Connect pods. Right now these are running as root which isn't ideal as it poses a security risk. If an attacker were to break into the container, they would have root access to install packages / look at things they should not be. Lastly an attacker breaking out of a container running as root would be root on a host.

## How was this patch tested?

helm install with the modified chart locally against AWS EKS.
