### PR TITLE
Update Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,5 +1,5 @@
 def config = jobConfig {
-    slackChannel = 'tools-notifications'
+    slackChannel = 'devprod-notifications'
 }
 
 def job = {


### PR DESCRIPTION
Problem:
Tools has been rebranded to DevProd and slack channels have changed. We are no longer receiving notifications from projects that notify 'tools-eng' and 'tools-notifications' channel.

Solution:
Change 'tools-eng' and 'tools-notifications' references to 'devprod-eng' and 'devprod-notifications' respectively.
