### PR TITLE
rename schema registry ports

### DIFF
--- a/charts/cp-schema-registry/templates/deployment.yaml
+++ b/charts/cp-schema-registry/templates/deployment.yaml
@@ -64,7 +64,7 @@ spec:
           image: "{{ .Values.image }}:{{ .Values.imageTag }}"
           imagePullPolicy: "{{ .Values.imagePullPolicy }}"
           ports:
-            - name: schema-registry
+            - name: http
               containerPort: {{ .Values.servicePort }}
               protocol: TCP
             {{- if .Values.prometheus.jmx.enabled }}

--- a/charts/cp-schema-registry/templates/service.yaml
+++ b/charts/cp-schema-registry/templates/service.yaml
@@ -1,7 +1,12 @@
+{{- $servicename := (include "cp-schema-registry.fullname" .) -}}
+{{ if or (eq $servicename "schema-registry") (eq $servicename "schema_registry")  }}
+    {{- fail "setting fullname to schema registry will require app to fail due to host environments: https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/#environment-variables" }}
+{{- end -}}
+
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "cp-schema-registry.fullname" . }}
+  name: {{ $servicename }}
   labels:
     app: {{ template "cp-schema-registry.name" . }}
     chart: {{ template "cp-schema-registry.chart" . }}
@@ -9,7 +14,7 @@ metadata:
     heritage: {{ .Release.Service }}
 spec:
   ports:
-    - name: schema-registry
+    - name: http
       port: {{ .Values.servicePort }}
     {{- if .Values.prometheus.jmx.enabled }}
     - name: metrics


### PR DESCRIPTION
## What changes were proposed in this pull request?

When installing the helm chart, I ran into a startup failure due to the environment variable `SCHEMA_REGISTRY_PORT` being set. To avoid this, I am proposing changing all named ports and perform a validation check to on the service to ensure that it is not being name schema-registry, which according to the [docs](https://kubernetes.io/docs/concepts/services-networking/connect-applications-service/#environment-variables), sets the service name as an active environment. This causes an exit status on the app https://github.com/confluentinc/schema-registry/issues/689. 

## How was this patch tested?
I set fullnameOverride in the values file and verified it errored.