### PR TITLE
FIXING_values.yaml-image-kafka-deprecated

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -43,7 +43,7 @@ cp-zookeeper:
 cp-kafka:
   enabled: true
   brokers: 3
-  image: confluentinc/cp-enterprise-kafka
+  image: confluentinc/cp-server
   imageTag: 6.1.0
   ## Optionally specify an array of imagePullSecrets. Secrets must be manually created in the namespace.
   ## https://kubernetes.io/docs/concepts/containers/images/#specifying-imagepullsecrets-on-a-pod


### PR DESCRIPTION
## What changes were proposed in this pull request?

Fixing a deprecated image repository to a current one

_deprecated kafka image repo and in master_
https://hub.docker.com/r/confluentinc/cp-enterprise-kafka

_current kafka image rep_o
https://hub.docker.com/r/confluentinc/cp-server

## How was this patch tested?

tested via helm with argocd and AKS
