### PR TITLE
Updated kafka image to open source cp-kafka from  licensed cp-server

### DIFF
--- a/charts/cp-kafka/values.yaml
+++ b/charts/cp-kafka/values.yaml
@@ -10,8 +10,8 @@
 brokers: 3
 
 ## Image Info
-## ref: https://hub.docker.com/r/confluentinc/cp-server/
-image: confluentinc/cp-server
+## ref: https://hub.docker.com/r/confluentinc/cp-kafka/
+image: confluentinc/cp-kafka
 imageTag: 6.1.0
 
 ## Specify a imagePullPolicy


### PR DESCRIPTION

## What changes were proposed in this pull request?

cp-kafka is the open source alternative to confluent licensed cp-server which got confluent commercially licensed features.

(Please fill in changes proposed in this fix)

## How was this patch tested?

installed helm chart with this change and test in the README worked. Env single node K8s cluster on Docker Desktop

(Please explain how this patch was tested. E.g. helm upgrade on minikube, helm install on gke)
