### PR TITLE
Feature/add sa

### DIFF
--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -33,6 +33,10 @@ spec:
       {{- end }}
       {{- end }}
     spec:
+      {{- if .Values.serviceAccount }}    
+      serviceAccountName: {{ template "cp-kafka-connect.fullname" . }}
+      automountServiceAccountToken: false
+      {{- end }}
       containers:
         {{- if .Values.prometheus.jmx.enabled }}
         - name: prometheus-jmx-exporter

--- a/charts/cp-kafka-connect/templates/servcieaccount.yaml
+++ b/charts/cp-kafka-connect/templates/servcieaccount.yaml
@@ -1,0 +1,15 @@
+{{- if .Values.serviceAccount }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "cp-kafka-connect.fullname" . }}
+  {{- if .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml .Values.serviceAccount.annotations | nindent 4 }}
+  {{- end }}
+  labels:
+    app: {{ template "cp-kafka-connect.name" . }}
+    chart: {{ template "cp-kafka-connect.chart" . }}
+    release: {{ .Release.Name }}
+    heritage: {{ .Release.Service }}
+{{- end }}

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -133,3 +133,7 @@ livenessProbe:
   # initialDelaySeconds: 30
   # periodSeconds: 5
   # failureThreshold: 10
+
+serviceAccount:
+  # annotations:
+  #   eks.amazonaws.com/role-arn: ""


### PR DESCRIPTION
Propose:
Since there are many kafka connectors that connect to aws, I thought it would be good to support IRSA as a template, so I created the PR.

ref.
- https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html
- https://kubernetes.io/docs/tasks/configure-pod-container/configure-service-account/#use-the-default-service-account-to-access-the-api-server