### PR TITLE
feat: adding ksqldb helm chart support for initcontainer, volumes and mounts

### DIFF
--- a/charts/cp-ksql-server/templates/deployment.yaml
+++ b/charts/cp-ksql-server/templates/deployment.yaml
@@ -33,6 +33,13 @@ spec:
       {{- end }}
       {{- end }}
     spec:
+      {{- if hasKey .Values "initContainers" }}
+      initContainers:
+{{- range $key, $value := .Values.initContainers }}
+      - name: {{ $key }}
+{{ toYaml $value | trim | indent 8 }}
+{{- end }}
+      {{- end }}
       containers:
         {{- if .Values.prometheus.jmx.enabled }}
         - name: prometheus-jmx-exporter
@@ -74,6 +81,9 @@ spec:
           - name: ksql-queries
             mountPath: /etc/ksql/queries
           {{- end }}
+{{- if hasKey .Values "extraVolumeMounts" }}
+{{ toYaml .Values.extraVolumeMounts | trim | indent 10 }}
+{{ end }}
           env:
           - name: KSQL_BOOTSTRAP_SERVERS
             value: {{ template "cp-ksql-server.kafka.bootstrapServers" . }}
@@ -103,6 +113,9 @@ spec:
 {{ toYaml .Values.imagePullSecrets | indent 8 }}
       {{- end }}
       volumes:
+{{- if hasKey .Values "extraVolumes" }}
+{{ toYaml .Values.extraVolumes | trim | indent 6 }}
+{{- end }}
       {{- if .Values.prometheus.jmx.enabled }}
       - name: jmx-config
         configMap:

--- a/values.yaml
+++ b/values.yaml
@@ -148,6 +148,30 @@ cp-ksql-server:
   ksql:
     headless: false
 
+  ## Optionally add init containers that initialises ksqldb, like adding ksqldb-udfs in a mounted volume
+  # initContainers:
+  #   init:
+  #     image: busybox:latest
+  #     imagePullPolicy: IfNotPresent
+  #     command:
+  #     - sh
+  #     - -c
+  #     - |
+  #       touch /opt/ksqldb-udfs/additional-file
+  #     volumeMounts:
+  #     - mountPath: /opt/ksqldb-udfs
+  #       name: extensions-volume
+
+  ## Optionally mounts volumes to the cp-ksql-server container
+  # extraVolumeMounts:
+  # - mountPath: /opt/ksqldb-udfs
+  #   name: extensions-volume
+
+  ## Optionally adds additional volumes to this pod
+  # extraVolumes:
+  # - name: extensions-volume
+  #   emptyDir: {}
+
 ## ------------------------------------------------------
 ## Control Center
 ## ------------------------------------------------------


### PR DESCRIPTION
## What changes were proposed in this pull request?

The changes proposed in this pull request are to enable `initContainers` to be specified by the deployer by adding the container's key, and then all the properties required for the `initContainer` (see below for further details). 

Additional volumes for this pod can be defined by adding the `extraVolumes` key and then entering the details of the volume/s required

Volumes can be mounted on the cp-ksql-server container by specifying the `extraVolumeMounts` key and entering the volume mount details

(Please fill in changes proposed in this fix)
The following setup can be added to Values file and provides support for udf functions to be applied at pod initialisation time. The below example simply creates an empty file, but the ksqldb jar file can either be downloaded via curl, or else packaged inside a docker container, that can be used as the initialisation image to then transfer the jar files to the empty directly volume that is created in extraVolumes and mounted by extraVolumeMounts so that ksqldb can then access it.

```
## Optionally add init containers that initialises ksqldb, like adding ksqldb-udfs in a mounted volume

configurationOverrides:
    ksql.extension.dir: "/opt/ksqldb-udfs"

initContainers:
     init:
       image: busybox:latest
       imagePullPolicy: IfNotPresent
       command:
       - sh
       - -c
       - |
         touch /opt/ksqldb-udfs/additional-file
       volumeMounts:
       - mountPath: /opt/ksqldb-udfs
         name: extensions-volume

  ## Optionally mounts volumes to the cp-ksql-server container
  extraVolumeMounts:
  - mountPath: /opt/ksqldb-udfs
     name: extensions-volume

  ## Optionally adds additional volumes to this pod
  extraVolumes:
  - name: extensions-volume
     emptyDir: {}
```

## How was this patch tested?
(Please explain how this patch was tested. E.g. helm upgrade on minikube, helm install on gke)

This functionality has been tested on a k3d kubernetes cluster that was previously running ksqldb-server (version 0.26.0). I have applied the configurations shown above to create an emptyDir volume mounted on both an initContainer and the cp-ksql-server container. The initcontainer simply creates an empty file on the volume mount.

When the pod has been initialised and running successfully, I entered the shell using the command `kubectl exec -it <pod name> -- bash` and verified that file `/opt/ksqldb-udfs/additional-file` has been created successfully.

The configurations have been removed in order to verify that when they are disabled, the application is able to run successfully, thus ensuing that when the configurations are disabled, the chart does not fail.