### PR TITLE
fix(poddisruptionbudget): update apiVersion

### DIFF
--- a/charts/cp-zookeeper/templates/poddisruptionbudget.yaml
+++ b/charts/cp-zookeeper/templates/poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "cp-zookeeper.fullname" . }}-pdb


### PR DESCRIPTION
resolves #620

## What changes were proposed in this pull request?

Update apiVersion on PodDisruptionBudget to be compatible with Kubernetes 1.25

## How was this patch tested?

helm upgrade on bare metal k8s