### PR TITLE
feat: Adding support for specifying serviceAccountName in cp-schema-registry

### DIFF
--- a/charts/cp-schema-registry/templates/deployment.yaml
+++ b/charts/cp-schema-registry/templates/deployment.yaml
@@ -33,9 +33,9 @@ spec:
       {{- end }}
       {{- end }}
     spec:
-      {{- if .Values.serviceAccountName }}
-        serviceAccountName: {{ .Values.serviceAccountName }}
-      {{- end }}
+    {{- if .Values.serviceAccountName }}
+      serviceAccountName: {{ .Values.serviceAccountName }}
+    {{- end }}
       securityContext:
       {{- if .Values.securityContext }}
 {{ toYaml .Values.securityContext | indent 8 }}

--- a/charts/cp-schema-registry/templates/deployment.yaml
+++ b/charts/cp-schema-registry/templates/deployment.yaml
@@ -33,6 +33,9 @@ spec:
       {{- end }}
       {{- end }}
     spec:
+      {{- if .Values.serviceAccountName }}
+        serviceAccountName: {{ .Values.serviceAccountName }}
+      {{- end }}
       securityContext:
       {{- if .Values.securityContext }}
 {{ toYaml .Values.securityContext | indent 8 }}


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add support for specifying serviceAccountName in cp-schema-registry chart.

## How was this patch tested?

Small change, was not tested.