### PR TITLE
Remove XX:+UseCGroupMemoryLimitForHeap option for Jmx exporter in order to wortk with Java > 11 images

### DIFF
--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -41,7 +41,6 @@ spec:
           command:
           - java
           - -XX:+UnlockExperimentalVMOptions
-          - -XX:+UseCGroupMemoryLimitForHeap
           - -XX:MaxRAMFraction=1
           - -XshowSettings:vm
           - -jar

--- a/charts/cp-kafka-rest/templates/deployment.yaml
+++ b/charts/cp-kafka-rest/templates/deployment.yaml
@@ -41,7 +41,6 @@ spec:
           command:
           - java
           - -XX:+UnlockExperimentalVMOptions
-          - -XX:+UseCGroupMemoryLimitForHeap
           - -XX:MaxRAMFraction=1
           - -XshowSettings:vm
           - -jar

--- a/charts/cp-ksql-server/templates/deployment.yaml
+++ b/charts/cp-ksql-server/templates/deployment.yaml
@@ -41,7 +41,6 @@ spec:
           command:
           - java
           - -XX:+UnlockExperimentalVMOptions
-          - -XX:+UseCGroupMemoryLimitForHeap
           - -XX:MaxRAMFraction=1
           - -XshowSettings:vm
           - -jar

--- a/charts/cp-schema-registry/templates/deployment.yaml
+++ b/charts/cp-schema-registry/templates/deployment.yaml
@@ -45,7 +45,6 @@ spec:
           command:
           - java
           - -XX:+UnlockExperimentalVMOptions
-          - -XX:+UseCGroupMemoryLimitForHeap
           - -XX:MaxRAMFraction=1
           - -XshowSettings:vm
           - -jar


### PR DESCRIPTION
## What changes were proposed in this pull request?

(Please fill in changes proposed in this fix)

## How was this patch tested?

(Please explain how this patch was tested. E.g. helm upgrade on minikube, helm install on gke)
