### PR TITLE
Update API version from v1beta1 to v1

### DIFF
--- a/charts/cp-zookeeper/templates/poddisruptionbudget.yaml
+++ b/charts/cp-zookeeper/templates/poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "cp-zookeeper.fullname" . }}-pdb


### PR DESCRIPTION
## What changes were proposed in this pull request?
For Zookeeper PodDistruptionBudget, change API version to policy/v1 instead of policy/v1beta1.

## How was this patch tested?
It was tested on Azure Kubernetes version 1.25.6 with Helm version 3.6.0.
