### PR TITLE
cp-kafka-connect: deploymentStrategy

### DIFF
--- a/charts/cp-kafka-connect/templates/deployment.yaml
+++ b/charts/cp-kafka-connect/templates/deployment.yaml
@@ -12,6 +12,10 @@ metadata:
     release: {{ .Release.Name }}
     heritage: {{ .Release.Service }}
 spec:
+  {{- if .Values.deploymentStrategy }}
+  strategy:
+    {{- toYaml .Values.deploymentStrategy | nindent 4 }}
+  {{- end }}
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:

--- a/charts/cp-kafka-connect/values.yaml
+++ b/charts/cp-kafka-connect/values.yaml
@@ -133,3 +133,10 @@ livenessProbe:
   # initialDelaySeconds: 30
   # periodSeconds: 5
   # failureThreshold: 10
+
+# Example deployment strategy
+# deploymentStrategy:
+#   type: RollingUpdate
+#   rollingUpdate:
+#     maxUnavailable: 1
+#     maxSurge: 1


### PR DESCRIPTION
## What changes were proposed in this pull request?

Allow setting the deployment startegy for the deployment

For example allow setting a RollingUpdate stategy.

Additional notes:
Currently, when we make a change to the deployment, all workers will get re-created at the same time.
With this addition, a change on the deployment, will not re-create all the workers at the same time, but in
a rolling restart way.

## How was this patch tested?

Locally using minikube 