### PR TITLE
Replace policy/v1beta1 with policy/v1

### DIFF
--- a/charts/cp-zookeeper/templates/poddisruptionbudget.yaml
+++ b/charts/cp-zookeeper/templates/poddisruptionbudget.yaml
@@ -1,4 +1,8 @@
+{{- if .Capabilities.APIVersions.Has "policy/v1" }}
+apiVersion: policy/v1
+{{- else }}
 apiVersion: policy/v1beta1
+{{- end }}
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "cp-zookeeper.fullname" . }}-pdb


### PR DESCRIPTION
## What changes were proposed in this pull request?

Add `policy/v1` for PDB creation on K8s 1.25

## How was this patch tested?

(Please explain how this patch was tested. E.g. helm upgrade on minikube, helm install on gke)
