### PR TITLE
Update poddisruptionbudget.yaml

### DIFF
--- a/charts/cp-zookeeper/templates/poddisruptionbudget.yaml
+++ b/charts/cp-zookeeper/templates/poddisruptionbudget.yaml
@@ -1,4 +1,4 @@
-apiVersion: policy/v1beta1
+apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
   name: {{ template "cp-zookeeper.fullname" . }}-pdb


### PR DESCRIPTION
change apiVersion for PodDisruptionBudget

## What changes were proposed in this pull request?
Change the apiVersion for PodDisruptionBudget to `policy/v1` since it was moved from `policy/v1beta1`
## How was this patch tested?
Not tested
(Please explain how this patch was tested. E.g. helm upgrade on minikube, helm install on gke)
